### PR TITLE
feat: add completed_at timestamp to TokenMutableState

### DIFF
--- a/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
@@ -574,7 +574,7 @@ mod MockMinigameTokenFuzz {
         }
 
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {

--- a/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
@@ -870,7 +870,7 @@ mod MockMinigameTokenForLibs {
         }
 
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {
@@ -1743,7 +1743,7 @@ mod MockMinigameTokenWithRegistry {
             self.token_game_address.read(token_id)
         }
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {

--- a/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
@@ -695,7 +695,7 @@ mod MockMinigameToken {
         }
 
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {

--- a/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
@@ -521,7 +521,7 @@ mod MockTokenContract {
         }
 
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {

--- a/packages/embeddable_game_standard/src/token/structs.cairo
+++ b/packages/embeddable_game_standard/src/token/structs.cairo
@@ -87,24 +87,29 @@ pub struct PackedTokenId {
 }
 
 /// StorePacking implementation for TokenMutableState
-/// Packs 2 boolean fields into a single felt252 (uses only 2 bits)
-/// This is the most gas-efficient way to store boolean flags in Cairo.
+/// Packs 2 boolean fields + completed_at timestamp into a single felt252
+/// Layout: game_over(1) | completed_objective(1) | completed_at(32) = 34 bits
 pub impl TokenMutableStateStorePacking of StorePacking<TokenMutableState, felt252> {
     fn pack(value: TokenMutableState) -> felt252 {
-        let mut packed: u8 = 0;
+        let mut packed: u128 = 0;
         if value.game_over {
             packed = packed | 0x1; // bit 0
         }
         if value.completed_objective {
             packed = packed | 0x2; // bit 1
         }
+        packed = packed + Into::<u32, u128>::into(value.completed_at) * 0x4; // shift 2
         packed.into()
     }
 
     fn unpack(value: felt252) -> TokenMutableState {
-        let packed: u8 = value.try_into().unwrap();
+        let packed: u128 = value.try_into().unwrap();
+        let (hi, flags) = DivRem::div_rem(packed, 0x4); // extract 2 flag bits
+        let flags_u8: u8 = flags.try_into().unwrap();
         TokenMutableState {
-            game_over: (packed & 0x1) != 0, completed_objective: (packed & 0x2) != 0,
+            game_over: (flags_u8 & 0x1) != 0,
+            completed_objective: (flags_u8 & 0x2) != 0,
+            completed_at: hi.try_into().unwrap(),
         }
     }
 }

--- a/packages/embeddable_game_standard/src/token/tests/test_structs_coverage.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_structs_coverage.cairo
@@ -103,7 +103,7 @@ fn test_token_mutable_state_default() {
 
 #[test]
 fn test_token_mutable_state_pack_unpack_both_false() {
-    let state = TokenMutableState { game_over: false, completed_objective: false };
+    let state = TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 };
     let packed = TokenMutableStateStorePacking::pack(state);
     let unpacked = TokenMutableStateStorePacking::unpack(packed);
 
@@ -113,7 +113,7 @@ fn test_token_mutable_state_pack_unpack_both_false() {
 
 #[test]
 fn test_token_mutable_state_pack_unpack_both_true() {
-    let state = TokenMutableState { game_over: true, completed_objective: true };
+    let state = TokenMutableState { game_over: true, completed_objective: true, completed_at: 0 };
     let packed = TokenMutableStateStorePacking::pack(state);
     let unpacked = TokenMutableStateStorePacking::unpack(packed);
 
@@ -123,7 +123,7 @@ fn test_token_mutable_state_pack_unpack_both_true() {
 
 #[test]
 fn test_token_mutable_state_pack_unpack_game_over_only() {
-    let state = TokenMutableState { game_over: true, completed_objective: false };
+    let state = TokenMutableState { game_over: true, completed_objective: false, completed_at: 0 };
     let packed = TokenMutableStateStorePacking::pack(state);
     let unpacked = TokenMutableStateStorePacking::unpack(packed);
 
@@ -133,7 +133,7 @@ fn test_token_mutable_state_pack_unpack_game_over_only() {
 
 #[test]
 fn test_token_mutable_state_pack_unpack_completed_objective_only() {
-    let state = TokenMutableState { game_over: false, completed_objective: true };
+    let state = TokenMutableState { game_over: false, completed_objective: true, completed_at: 0 };
     let packed = TokenMutableStateStorePacking::pack(state);
     let unpacked = TokenMutableStateStorePacking::unpack(packed);
 
@@ -151,7 +151,7 @@ fn test_token_mutable_state_bit_isolation() {
     let mut i = 0;
     while i < states.len() {
         let (game_over, completed_objective) = *states.at(i);
-        let state = TokenMutableState { game_over, completed_objective };
+        let state = TokenMutableState { game_over, completed_objective, completed_at: 0 };
         let packed = TokenMutableStateStorePacking::pack(state);
         let unpacked = TokenMutableStateStorePacking::unpack(packed);
 
@@ -290,7 +290,7 @@ fn test_to_token_metadata_conversion_zeros() {
         metadata: 0,
     };
 
-    let mutable_state = TokenMutableState { game_over: false, completed_objective: false };
+    let mutable_state = TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 };
 
     let metadata = to_token_metadata(packed_id, mutable_state);
 
@@ -324,7 +324,7 @@ fn test_to_token_metadata_conversion_full() {
         metadata: 456,
     };
 
-    let mutable_state = TokenMutableState { game_over: true, completed_objective: true };
+    let mutable_state = TokenMutableState { game_over: true, completed_objective: true, completed_at: 0 };
 
     let metadata = to_token_metadata(packed_id, mutable_state);
 
@@ -364,13 +364,13 @@ fn test_to_token_metadata_mutable_state_independence() {
     };
 
     // Test game_over = true, completed_objective = false
-    let mutable_state1 = TokenMutableState { game_over: true, completed_objective: false };
+    let mutable_state1 = TokenMutableState { game_over: true, completed_objective: false, completed_at: 0 };
     let metadata1 = to_token_metadata(packed_id, mutable_state1);
     assert!(metadata1.game_over, "game_over should be true");
     assert!(!metadata1.completed_objective, "completed_objective should be false");
 
     // Test game_over = false, completed_objective = true
-    let mutable_state2 = TokenMutableState { game_over: false, completed_objective: true };
+    let mutable_state2 = TokenMutableState { game_over: false, completed_objective: true, completed_at: 0 };
     let metadata2 = to_token_metadata(packed_id, mutable_state2);
     assert!(!metadata2.game_over, "game_over should be false");
     assert!(metadata2.completed_objective, "completed_objective should be true");
@@ -458,7 +458,7 @@ fn test_fuzz_lifecycle_pack_unpack(start: u64, end: u64) {
 #[test]
 #[fuzzer(runs: 100)]
 fn test_fuzz_token_mutable_state_pack_unpack(game_over: bool, completed_objective: bool) {
-    let state = TokenMutableState { game_over, completed_objective };
+    let state = TokenMutableState { game_over, completed_objective, completed_at: 0 };
     let packed = TokenMutableStateStorePacking::pack(state);
     let unpacked = TokenMutableStateStorePacking::unpack(packed);
 

--- a/packages/embeddable_game_standard/src/token/tests/test_structs_coverage.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_structs_coverage.cairo
@@ -290,7 +290,9 @@ fn test_to_token_metadata_conversion_zeros() {
         metadata: 0,
     };
 
-    let mutable_state = TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 };
+    let mutable_state = TokenMutableState {
+        game_over: false, completed_objective: false, completed_at: 0,
+    };
 
     let metadata = to_token_metadata(packed_id, mutable_state);
 
@@ -324,7 +326,9 @@ fn test_to_token_metadata_conversion_full() {
         metadata: 456,
     };
 
-    let mutable_state = TokenMutableState { game_over: true, completed_objective: true, completed_at: 0 };
+    let mutable_state = TokenMutableState {
+        game_over: true, completed_objective: true, completed_at: 0,
+    };
 
     let metadata = to_token_metadata(packed_id, mutable_state);
 
@@ -364,13 +368,17 @@ fn test_to_token_metadata_mutable_state_independence() {
     };
 
     // Test game_over = true, completed_objective = false
-    let mutable_state1 = TokenMutableState { game_over: true, completed_objective: false, completed_at: 0 };
+    let mutable_state1 = TokenMutableState {
+        game_over: true, completed_objective: false, completed_at: 0,
+    };
     let metadata1 = to_token_metadata(packed_id, mutable_state1);
     assert!(metadata1.game_over, "game_over should be true");
     assert!(!metadata1.completed_objective, "completed_objective should be false");
 
     // Test game_over = false, completed_objective = true
-    let mutable_state2 = TokenMutableState { game_over: false, completed_objective: true, completed_at: 0 };
+    let mutable_state2 = TokenMutableState {
+        game_over: false, completed_objective: true, completed_at: 0,
+    };
     let metadata2 = to_token_metadata(packed_id, mutable_state2);
     assert!(!metadata2.game_over, "game_over should be false");
     assert!(metadata2.completed_objective, "completed_objective should be true");

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -660,8 +660,15 @@ pub mod CoreTokenComponent {
             // Update mutable state if changed
             if final_completed_objective != mutable_state.completed_objective
                 || final_game_over != mutable_state.game_over {
+                let completed_at: u32 = if objective_complete_transition {
+                    get_block_timestamp().try_into().unwrap()
+                } else {
+                    mutable_state.completed_at
+                };
                 let updated_state = TokenMutableState {
-                    game_over: final_game_over, completed_objective: final_completed_objective,
+                    game_over: final_game_over,
+                    completed_objective: final_completed_objective,
+                    completed_at,
                 };
                 self.token_mutable_state.entry(token_id).write(updated_state);
             }

--- a/packages/interfaces/src/structs/token.cairo
+++ b/packages/interfaces/src/structs/token.cairo
@@ -73,17 +73,18 @@ pub struct PlayerNameUpdate {
     pub name: felt252,
 }
 
-/// Mutable token state (game_over and completed_objective flags)
+/// Mutable token state (game_over, completed_objective, and completion timestamp)
 /// Used for efficient queries without parsing packed token data
 #[derive(Copy, Drop, Serde)]
 pub struct TokenMutableState {
     pub game_over: bool,
     pub completed_objective: bool,
+    pub completed_at: u32,
 }
 
 impl TokenMutableStateDefault of Default<TokenMutableState> {
     fn default() -> TokenMutableState {
-        TokenMutableState { game_over: false, completed_objective: false }
+        TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
     }
 }
 

--- a/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
+++ b/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
@@ -1080,7 +1080,7 @@ mod MockMinigameTokenForTicketBooth {
         }
 
         fn token_mutable_state(self: @ContractState, token_id: felt252) -> TokenMutableState {
-            TokenMutableState { game_over: false, completed_objective: false }
+            TokenMutableState { game_over: false, completed_objective: false, completed_at: 0 }
         }
 
         fn client_url(self: @ContractState, token_id: felt252) -> ByteArray {


### PR DESCRIPTION
## Summary

- Adds `completed_at: u32` field to `TokenMutableState` — stores the block timestamp when a token's objective is first completed
- Enables permissionless completion recording in metagame contracts (e.g., Bokendo's `record_completion`) without relying on callbacks
- Updated `StorePacking` layout: 2 bools + u32 timestamp = 34 bits packed into a single felt252

### Changes
- `packages/interfaces/src/structs/token.cairo` — added `completed_at: u32` to struct and default
- `packages/embeddable_game_standard/src/token/structs.cairo` — updated `StorePacking` to pack/unpack the new field
- `packages/embeddable_game_standard/src/token/token_component.cairo` — sets `completed_at = get_block_timestamp()` on objective completion transition in `update_game`
- Test files — added `completed_at: 0` to all `TokenMutableState` literals

## Test plan
- [ ] `scarb test` — all existing tests pass
- [ ] StorePacking roundtrip: `completed_at` survives pack/unpack
- [ ] `completed_at` is only set on objective completion transition (not on subsequent `update_game` calls)
- [ ] `completed_at` remains 0 for tokens that never complete their objective

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token records now include a completion timestamp, so the system records when objectives are completed.

* **Refactor**
  * Internal state packing/storage updated to support the new timestamp and preserve existing flags.
  * Token update logic now sets the completion timestamp on objective completion.

* **Tests**
  * Tests updated to cover timestamp initialization, packing/unpacking, and state roundtrips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->