### PR TITLE
feat: expose find_position as public view on ILeaderboard

### DIFF
--- a/packages/interfaces/src/leaderboard.cairo
+++ b/packages/interfaces/src/leaderboard.cairo
@@ -10,9 +10,9 @@ pub use crate::structs::leaderboard::{
 
 /// SNIP-5 interface ID derived via src5_rs: XOR of extended function selectors
 /// - submit_score, get_entries, get_top_entries, get_position, qualifies,
-///   is_full, get_leaderboard_length, get_config
+///   is_full, get_leaderboard_length, get_config, find_position
 pub const ILEADERBOARD_ID: felt252 =
-    0x381684b12c5a80d08222695ee5eca750b99e56cb53101a47378c542859907e1;
+    0x117a0c835a5dbc7ad37e8f5dcd306fd4266da5696b19d15e93bb5f39328bb14;
 
 /// Interface for retrieving game scores
 /// Implemented by game contracts to provide score data for leaderboard entries
@@ -50,6 +50,10 @@ pub trait ILeaderboard<TState> {
 
     /// Get the configuration for a context's leaderboard
     fn get_config(self: @TState, context_id: u64) -> LeaderboardStoreConfig;
+
+    /// Find the position where a score would be inserted (1-based).
+    /// O(log n) binary search — use as a view function for off-chain position calculation.
+    fn find_position(self: @TState, context_id: u64, score: u64, token_id: felt252) -> Option<u32>;
 }
 
 /// Admin interface for leaderboard management

--- a/packages/metagame/src/leaderboard/leaderboard_component.cairo
+++ b/packages/metagame/src/leaderboard/leaderboard_component.cairo
@@ -249,6 +249,17 @@ pub mod LeaderboardComponent {
                 game_address: self.game_address.read(context_id),
             }
         }
+
+        fn find_position(
+            self: @ComponentState<TContractState>, context_id: u64, score: u64, token_id: felt252,
+        ) -> Option<u32> {
+            let config = LeaderboardStoreConfig {
+                max_entries: self.max_entries.read(context_id),
+                ascending: self.ascending.read(context_id),
+                game_address: self.game_address.read(context_id),
+            };
+            LeaderboardStoreHelpersTrait::find_position(self, context_id, score, token_id, config)
+        }
     }
 
     #[embeddable_as(LeaderboardAdminImpl)]


### PR DESCRIPTION
## Summary

- Adds `find_position(context_id, score, token_id) -> Option<u32>` to the `ILeaderboard` interface as a public view function
- O(log n) binary search — enables off-chain position calculation via RPC when the indexer is unavailable
- Updates `ILEADERBOARD_ID` to include the new function's extended function selector

### Context

With the O(1) overwrite model from #96, callers must provide the correct position when submitting scores. The primary path is for the frontend/indexer to compute this off-chain. This view function provides an on-chain fallback for position calculation when the indexer is down.

## Test plan

- [x] All 112 metagame leaderboard tests pass
- [x] All 50 preset leaderboard tests pass
- [x] `scarb fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to find a user's potential rank/position for a given score on a leaderboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->