### PR TITLE
feat: bump metagame_extensions to v0.1.3 (per-context bannable)

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -37,7 +37,7 @@ openzeppelin_introspection = { git = "https://github.com/OpenZeppelin/cairo-cont
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 openzeppelin_interfaces = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts.git", tag = "v4.0.1" }
-metagame_extensions_interfaces = { git = "https://github.com/Provable-Games/metagame_extensions.git", tag = "v0.1.2" }
+metagame_extensions_interfaces = { git = "https://github.com/Provable-Games/metagame_extensions.git", tag = "v0.1.3" }
 
 [dependencies]
 starknet.workspace = true

--- a/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
@@ -8,7 +8,9 @@ pub mod AcceptingLimitedEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -18,7 +20,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        registration_only: bool,
+        bannable: Map<u64, bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -31,9 +33,8 @@ pub mod AcceptingLimitedEntryValidatorMock {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, registration_only: bool) {
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.owner_address.write(owner);
-        self.registration_only.write(registration_only);
         self.src5.register_interface(IENTRY_REQUIREMENT_EXTENSION_ID);
     }
 
@@ -43,8 +44,8 @@ pub mod AcceptingLimitedEntryValidatorMock {
             self.owner_address.read()
         }
 
-        fn registration_only(self: @ContractState) -> bool {
-            self.registration_only.read()
+        fn bannable(self: @ContractState, context_id: u64) -> bool {
+            self.bannable.read(context_id)
         }
 
         fn valid_entry(

--- a/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
@@ -8,7 +8,9 @@ pub mod EntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -18,7 +20,7 @@ pub mod EntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        registration_only: bool,
+        bannable: Map<u64, bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -31,9 +33,8 @@ pub mod EntryValidatorMock {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, registration_only: bool) {
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.owner_address.write(owner);
-        self.registration_only.write(registration_only);
         self.src5.register_interface(IENTRY_REQUIREMENT_EXTENSION_ID);
     }
 
@@ -43,8 +44,8 @@ pub mod EntryValidatorMock {
             self.owner_address.read()
         }
 
-        fn registration_only(self: @ContractState) -> bool {
-            self.registration_only.read()
+        fn bannable(self: @ContractState, context_id: u64) -> bool {
+            self.bannable.read(context_id)
         }
 
         fn valid_entry(

--- a/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
@@ -7,7 +7,9 @@ pub mod RejectingEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -17,7 +19,7 @@ pub mod RejectingEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        registration_only: bool,
+        bannable: Map<u64, bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -30,9 +32,8 @@ pub mod RejectingEntryValidatorMock {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, registration_only: bool) {
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.owner_address.write(owner);
-        self.registration_only.write(registration_only);
         self.src5.register_interface(IENTRY_REQUIREMENT_EXTENSION_ID);
     }
 
@@ -42,8 +43,8 @@ pub mod RejectingEntryValidatorMock {
             self.owner_address.read()
         }
 
-        fn registration_only(self: @ContractState) -> bool {
-            self.registration_only.read()
+        fn bannable(self: @ContractState, context_id: u64) -> bool {
+            self.bannable.read(context_id)
         }
 
         fn valid_entry(

--- a/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
@@ -108,7 +108,7 @@ fn test_set_and_get_token_requirement() {
 fn test_set_and_get_extension_requirement() {
     let mock = deploy_entry_requirement_mock();
     let owner = make_address(0x1);
-    let ext_addr = deploy_entry_validator_mock(owner, false);
+    let ext_addr = deploy_entry_validator_mock(owner);
     let config_data: Array<felt252> = array![1, 2, 3];
     let context_id: u64 = 77;
 
@@ -403,24 +403,20 @@ fn deploy_erc721_mock() -> ContractAddress {
     contract_address
 }
 
-fn deploy_entry_validator_mock(owner: ContractAddress, registration_only: bool) -> ContractAddress {
+fn deploy_entry_validator_mock(owner: ContractAddress) -> ContractAddress {
     let contract_class = declare("EntryValidatorMock").expect('declare failed').contract_class();
     let mut calldata = array![];
     owner.serialize(ref calldata);
-    registration_only.serialize(ref calldata);
     let (contract_address, _) = contract_class.deploy(@calldata).expect('deploy failed');
     contract_address
 }
 
-fn deploy_rejecting_entry_validator_mock(
-    owner: ContractAddress, registration_only: bool,
-) -> ContractAddress {
+fn deploy_rejecting_entry_validator_mock(owner: ContractAddress) -> ContractAddress {
     let contract_class = declare("RejectingEntryValidatorMock")
         .expect('declare failed')
         .contract_class();
     let mut calldata = array![];
     owner.serialize(ref calldata);
-    registration_only.serialize(ref calldata);
     let (contract_address, _) = contract_class.deploy(@calldata).expect('deploy failed');
     contract_address
 }
@@ -483,7 +479,7 @@ fn test_validate_qualification_token_nonexistent_nft() {
 fn test_validate_qualification_extension_returns_caller() {
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_entry_validator_mock(caller, false);
+    let validator_addr = deploy_entry_validator_mock(caller);
 
     let req = EntryRequirement {
         entry_limit: 1,
@@ -506,7 +502,7 @@ fn test_validate_qualification_extension_returns_caller() {
 fn test_validate_qualification_extension_rejects() {
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_rejecting_entry_validator_mock(caller, false);
+    let validator_addr = deploy_rejecting_entry_validator_mock(caller);
 
     let req = EntryRequirement {
         entry_limit: 1,
@@ -528,7 +524,7 @@ fn test_validate_qualification_extension_rejects() {
 fn test_validate_qualification_extension_wrong_proof_type() {
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_entry_validator_mock(caller, false);
+    let validator_addr = deploy_entry_validator_mock(caller);
 
     let req = EntryRequirement {
         entry_limit: 1,
@@ -566,7 +562,7 @@ fn test_assert_valid_entry_requirement_token_erc721() {
 fn test_assert_valid_entry_requirement_token_not_erc721() {
     let mock = deploy_entry_requirement_mock();
     // Deploy an entry validator (which doesn't support IERC721)
-    let non_erc721_addr = deploy_entry_validator_mock(make_address(0x1), false);
+    let non_erc721_addr = deploy_entry_validator_mock(make_address(0x1));
 
     let req = EntryRequirement {
         entry_limit: 1, entry_requirement_type: EntryRequirementType::token(non_erc721_addr),
@@ -578,7 +574,7 @@ fn test_assert_valid_entry_requirement_token_not_erc721() {
 #[test]
 fn test_assert_valid_entry_requirement_extension_valid() {
     let mock = deploy_entry_requirement_mock();
-    let validator_addr = deploy_entry_validator_mock(make_address(0x1), false);
+    let validator_addr = deploy_entry_validator_mock(make_address(0x1));
 
     let req = EntryRequirement {
         entry_limit: 1,
@@ -628,15 +624,12 @@ fn test_assert_valid_entry_requirement_extension_not_entry_validator() {
 // Helper deploy function for AcceptingLimitedEntryValidatorMock
 // ============================================================================
 
-fn deploy_accepting_limited_entry_validator_mock(
-    owner: ContractAddress, registration_only: bool,
-) -> ContractAddress {
+fn deploy_accepting_limited_entry_validator_mock(owner: ContractAddress) -> ContractAddress {
     let contract_class = declare("AcceptingLimitedEntryValidatorMock")
         .expect('declare failed')
         .contract_class();
     let mut calldata = array![];
     owner.serialize(ref calldata);
-    registration_only.serialize(ref calldata);
     let (contract_address, _) = contract_class.deploy(@calldata).expect('deploy failed');
     contract_address
 }
@@ -651,7 +644,7 @@ fn test_update_qualification_entries_extension_none_entries_left() {
     // This means no limit check - should succeed silently
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_entry_validator_mock(caller, false);
+    let validator_addr = deploy_entry_validator_mock(caller);
     let context_id: u64 = 80;
 
     let req = EntryRequirement {
@@ -677,7 +670,7 @@ fn test_update_qualification_entries_extension_some_entries_remaining() {
     // entries_left > 0 - should succeed
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_accepting_limited_entry_validator_mock(caller, false);
+    let validator_addr = deploy_accepting_limited_entry_validator_mock(caller);
     let context_id: u64 = 81;
 
     let req = EntryRequirement {
@@ -704,7 +697,7 @@ fn test_update_qualification_entries_extension_zero_entries_left() {
     // entries_left == 0 - should panic
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_rejecting_entry_validator_mock(caller, false);
+    let validator_addr = deploy_rejecting_entry_validator_mock(caller);
     let context_id: u64 = 82;
 
     let req = EntryRequirement {
@@ -730,7 +723,7 @@ fn test_update_qualification_entries_extension_zero_entries_left() {
 fn test_update_qualification_entries_extension_wrong_proof_type() {
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
-    let validator_addr = deploy_entry_validator_mock(caller, false);
+    let validator_addr = deploy_entry_validator_mock(caller);
     let context_id: u64 = 83;
 
     let req = EntryRequirement {

--- a/packages/test_common/src/mocks/mock_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_entry_validator.cairo
@@ -8,7 +8,9 @@ pub mod EntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -18,7 +20,7 @@ pub mod EntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        registration_only: bool,
+        bannable: Map<u64, bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -31,9 +33,8 @@ pub mod EntryValidatorMock {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, registration_only: bool) {
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.owner_address.write(owner);
-        self.registration_only.write(registration_only);
         self.src5.register_interface(IENTRY_REQUIREMENT_EXTENSION_ID);
     }
 
@@ -43,8 +44,8 @@ pub mod EntryValidatorMock {
             self.owner_address.read()
         }
 
-        fn registration_only(self: @ContractState) -> bool {
-            self.registration_only.read()
+        fn bannable(self: @ContractState, context_id: u64) -> bool {
+            self.bannable.read(context_id)
         }
 
         fn valid_entry(

--- a/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
@@ -7,7 +7,9 @@ pub mod RejectingEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -17,7 +19,7 @@ pub mod RejectingEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        registration_only: bool,
+        bannable: Map<u64, bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -30,9 +32,8 @@ pub mod RejectingEntryValidatorMock {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress, registration_only: bool) {
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.owner_address.write(owner);
-        self.registration_only.write(registration_only);
         self.src5.register_interface(IENTRY_REQUIREMENT_EXTENSION_ID);
     }
 
@@ -42,8 +43,8 @@ pub mod RejectingEntryValidatorMock {
             self.owner_address.read()
         }
 
-        fn registration_only(self: @ContractState) -> bool {
-            self.registration_only.read()
+        fn bannable(self: @ContractState, context_id: u64) -> bool {
+            self.bannable.read(context_id)
         }
 
         fn valid_entry(


### PR DESCRIPTION
## Summary
- Bumps `metagame_extensions_interfaces` from v0.1.2 to v0.1.3
- Adapts mocks and tests to the renamed `bannable(context_id)` interface (formerly `registration_only()`)

## Context
metagame_extensions v0.1.3 made the bannable flag per-context rather than a global validator setting (Provable-Games/metagame_extensions#17). This requires interface implementers to update their mock signatures.

## Changes
- 5 mocks: `registration_only: bool` storage → `bannable: Map<u64, bool>`, removed from constructor
- 1 test file: removed `registration_only` from deploy helpers and call sites

## Test plan
- [x] `scarb build` passes
- [x] `snforge test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated metagame extension interfaces dependency to v0.1.3.

* **Updates**
  * Enhanced entry requirement validation system to support context-specific configuration instead of global settings.
  * Updated all test utilities and mock validator contracts to align with the revised requirement interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->