### PR TITLE
feat(entry-fee): move distribution state to EntryFeeComponent

### DIFF
--- a/packages/interfaces/src/entry_fee.cairo
+++ b/packages/interfaces/src/entry_fee.cairo
@@ -1,5 +1,6 @@
 use metagame_extensions_interfaces::extension::ExtensionConfig;
 use starknet::ContractAddress;
+use crate::distribution::Distribution;
 
 /// SNIP-5 interface ID derived via src5_rs: XOR of extended function selectors
 /// - get_entry_fee(u64)->Option<EntryFeeConfig>
@@ -27,6 +28,16 @@ pub struct EntryFeeConfig {
     pub refund_share: Option<u16>,
     /// Additional shares deducted before position distribution
     pub additional_shares: Span<AdditionalShare>,
+    /// Shape of the position-based payout for the remaining pool. `None`
+    /// means no position distribution is configured (refund-only /
+    /// additional-only fees). For `Distribution::Custom(shares)` the
+    /// component persists the shares array in packed storage and
+    /// `shares.len()` implicitly defines the paid-places count.
+    pub distribution: Option<Distribution>,
+    /// Number of paid places for position-based distribution. `0` means
+    /// "dynamic — use the actual leaderboard size at payout time". Ignored
+    /// when `distribution == None`.
+    pub distribution_count: u32,
 }
 
 /// Entry fee enum: dispatch to either store config or set extension

--- a/packages/metagame/src/entry_fee/entry_fee_component.cairo
+++ b/packages/metagame/src/entry_fee/entry_fee_component.cairo
@@ -10,6 +10,10 @@
 pub mod EntryFeeComponent {
     use core::num::traits::Zero;
     use game_components_interfaces::entry_fee::{IENTRY_FEE_ID, IEntryFee};
+    use game_components_utilities::distribution::packed_shares::CustomShares;
+    use game_components_utilities::distribution::structs::{
+        PackedDistribution, PackedDistributionStorePacking,
+    };
     use metagame_extensions_interfaces::entry_fee_extension::{
         IENTRY_FEE_EXTENSION_ID, IEntryFeeExtensionDispatcher, IEntryFeeExtensionDispatcherTrait,
     };
@@ -45,6 +49,17 @@ pub mod EntryFeeComponent {
         /// Each slot packs up to 16 shares (15 bits each = 240 bits per felt252)
         /// slot_index = share_index / 16
         EntryFee_additional_shares_packed: Map<(u64, u8), PackedAdditionalShares>,
+        /// Packed custom distribution shares per context: (context_id, slot_index) -> CustomShares
+        /// Each slot packs up to 15 u16 shares (16 bits each = 240 bits per felt252).
+        /// Unset unless the context uses a `Distribution::Custom` payout split.
+        /// The number of shares is the `positions` field of the sibling
+        /// `EntryFee_distribution` entry (they are written atomically in
+        /// `set_entry_fee_config`) — no separate count is stored.
+        EntryFee_distribution_shares_packed: Map<(u64, u8), CustomShares>,
+        /// Distribution shape + paid-places count packed into a single
+        /// felt252 (see `PackedDistribution`). Zero-valued when no
+        /// distribution is configured for the context.
+        EntryFee_distribution: Map<u64, PackedDistribution>,
         /// Refund claimed: (context_id, token_id) -> claimed
         EntryFee_refund_claimed: Map<(u64, felt252), bool>,
         /// Extension address for extension-enhanced entry fees
@@ -151,6 +166,35 @@ pub mod EntryFeeComponent {
         ) {
             self.EntryFee_extension_config.entry(context_id).push(value);
         }
+
+        fn get_distribution_shares_packed(
+            self: @ComponentState<TContractState>, context_id: u64, slot: u8,
+        ) -> CustomShares {
+            self.EntryFee_distribution_shares_packed.entry((context_id, slot)).read()
+        }
+
+        fn set_distribution_shares_packed(
+            ref self: ComponentState<TContractState>,
+            context_id: u64,
+            slot: u8,
+            shares: CustomShares,
+        ) {
+            self.EntryFee_distribution_shares_packed.entry((context_id, slot)).write(shares);
+        }
+
+        fn get_distribution(
+            self: @ComponentState<TContractState>, context_id: u64,
+        ) -> PackedDistribution {
+            self.EntryFee_distribution.entry(context_id).read()
+        }
+
+        fn set_distribution(
+            ref self: ComponentState<TContractState>,
+            context_id: u64,
+            distribution: PackedDistribution,
+        ) {
+            self.EntryFee_distribution.entry(context_id).write(distribution);
+        }
     }
 
     #[embeddable_as(EntryFeeImpl)]
@@ -182,6 +226,35 @@ pub mod EntryFeeComponent {
             self: @ComponentState<TContractState>, context_id: u64,
         ) -> Span<AdditionalShare> {
             EntryFeeStoreTrait::get_additional_shares(self, context_id)
+        }
+
+        /// Persist a custom distribution shares array for a context.
+        /// Packs 15 `u16` shares per `felt252` slot via `CustomShares`.
+        /// Consumers pair this with their own paid-places count semantics.
+        fn _store_distribution_shares(
+            ref self: ComponentState<TContractState>, context_id: u64, shares: Span<u16>,
+        ) {
+            EntryFeeStoreTrait::store_distribution_shares(ref self, context_id, shares);
+        }
+
+        /// Read `count` custom distribution shares for a context. Callers
+        /// supply the count (typically sourced from the sibling
+        /// `PackedDistribution.positions`); returns an empty array when
+        /// `count == 0`.
+        fn _get_distribution_shares(
+            self: @ComponentState<TContractState>, context_id: u64, count: u32,
+        ) -> Array<u16> {
+            EntryFeeStoreTrait::get_distribution_shares(self, context_id, count)
+        }
+
+        /// Read a single custom distribution share at a 1-indexed position.
+        /// O(1) — only one packed `felt252` slot is read. Use this in claim
+        /// paths instead of `_get_distribution_shares` when only one share
+        /// is needed.
+        fn _get_custom_share_at(
+            self: @ComponentState<TContractState>, context_id: u64, position: u32,
+        ) -> u16 {
+            EntryFeeStoreTrait::get_custom_share_at(self, context_id, position)
         }
 
         /// Set entry fee or extension for a context.

--- a/packages/metagame/src/entry_fee/entry_fee_store.cairo
+++ b/packages/metagame/src/entry_fee/entry_fee_store.cairo
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use core::num::traits::Zero;
+use game_components_interfaces::distribution::Distribution;
 use game_components_interfaces::entry_fee::{AdditionalShare, EntryFeeConfig};
+use game_components_utilities::distribution::packed_shares::{
+    CustomSharesImpl, CustomSharesTrait, SHARES_PER_SLOT as DISTRIBUTION_SHARES_PER_SLOT,
+    calculate_slot_position,
+};
+use game_components_utilities::distribution::structs::{
+    DIST_TYPE_CUSTOM, DIST_TYPE_EXPONENTIAL, DIST_TYPE_LINEAR, DIST_TYPE_UNIFORM,
+    PackedDistribution,
+};
 use starknet::ContractAddress;
 use crate::entry_fee::store::Store;
 use crate::entry_fee::structs::{
@@ -34,6 +43,21 @@ pub trait EntryFeeStoreTrait<T> {
     fn store_extension_address(ref self: T, context_id: u64, address: ContractAddress);
     /// Get extension address.
     fn get_extension(self: @T, context_id: u64) -> ContractAddress;
+    /// Persist a custom distribution shares array for a context, packed 15
+    /// per `felt252` slot. The share count is not stored here — callers must
+    /// ensure the sibling `PackedDistribution.positions` for this context
+    /// equals `shares.len()` (which `set_entry_fee_config` does atomically).
+    fn store_distribution_shares(ref self: T, context_id: u64, shares: Span<u16>);
+    /// Read `count` custom distribution shares for a context. Callers supply
+    /// the count (typically `get_distribution().positions`); returns an empty
+    /// array when `count == 0`.
+    fn get_distribution_shares(self: @T, context_id: u64, count: u32) -> Array<u16>;
+    /// Read a single custom distribution share at a 1-indexed position. Only
+    /// one packed slot is read — this is the O(1) fast path for claim sites
+    /// that need just one share, bypassing the full-array reconstruction.
+    /// Callers must ensure the position is in range (1..=positions) since no
+    /// bounds check is performed against the configured count.
+    fn get_custom_share_at(self: @T, context_id: u64, position: u32) -> u16;
 }
 
 pub impl EntryFeeStoreImpl<T, +Store<T>, +Drop<T>> of EntryFeeStoreTrait<T> {
@@ -63,6 +87,33 @@ pub impl EntryFeeStoreImpl<T, +Store<T>, +Drop<T>> of EntryFeeStoreTrait<T> {
             Option::Some(data.refund_share)
         };
 
+        // Rehydrate distribution shape + paid-places count. `dist_type == 0`
+        // paired with `positions == 0` and a zero param is the "unset"
+        // sentinel — return None so consumers can distinguish "no
+        // distribution configured" from "Linear with weight 0".
+        let packed_dist = self.get_distribution(context_id);
+        let (distribution, distribution_count) = if packed_dist.dist_type == DIST_TYPE_LINEAR
+            && packed_dist.dist_param == 0
+            && packed_dist.positions == 0 {
+            (Option::None, 0_u32)
+        } else if packed_dist.dist_type == DIST_TYPE_LINEAR {
+            (Option::Some(Distribution::Linear(packed_dist.dist_param)), packed_dist.positions)
+        } else if packed_dist.dist_type == DIST_TYPE_EXPONENTIAL {
+            (Option::Some(Distribution::Exponential(packed_dist.dist_param)), packed_dist.positions)
+        } else if packed_dist.dist_type == DIST_TYPE_UNIFORM {
+            (Option::Some(Distribution::Uniform), packed_dist.positions)
+        } else {
+            // DIST_TYPE_CUSTOM — return with empty shares span. Loading the
+            // full array is O(N/15) storage reads and is only needed for UI
+            // views; claim paths read a single share via `_get_custom_share_at`
+            // (O(1)). The strict-sum validator (Σshares == available_share
+            // at creation) means no dust needs to be tracked. Callers that
+            // need the full array (e.g. view functions) call
+            // `get_distribution_shares` explicitly, passing
+            // `packed_dist.positions` as the count.
+            (Option::Some(Distribution::Custom(array![].span())), packed_dist.positions)
+        };
+
         Option::Some(
             EntryFeeConfig {
                 token_address,
@@ -70,6 +121,8 @@ pub impl EntryFeeStoreImpl<T, +Store<T>, +Drop<T>> of EntryFeeStoreTrait<T> {
                 game_creator_share,
                 refund_share,
                 additional_shares,
+                distribution,
+                distribution_count,
             },
         )
     }
@@ -164,6 +217,35 @@ pub impl EntryFeeStoreImpl<T, +Store<T>, +Drop<T>> of EntryFeeStoreTrait<T> {
         if additional_count > 0 {
             self.set_packed_shares(context_id, current_slot, packed_shares);
         }
+
+        // Persist the distribution config (shape + paid-places count), and
+        // for Custom, the shares array in packed out-of-band storage.
+        let (dist_type, dist_param) = match config.distribution {
+            Option::None => (DIST_TYPE_LINEAR, 0_u16),
+            Option::Some(dist) => match dist {
+                Distribution::Linear(w) => (DIST_TYPE_LINEAR, *w),
+                Distribution::Exponential(w) => (DIST_TYPE_EXPONENTIAL, *w),
+                Distribution::Uniform => (DIST_TYPE_UNIFORM, 0_u16),
+                Distribution::Custom(_) => (DIST_TYPE_CUSTOM, 0_u16),
+            },
+        };
+        // For Custom, paid places are defined by the shares array length;
+        // otherwise use the configured count (0 = dynamic).
+        let positions: u32 = match config.distribution {
+            Option::Some(dist) => match dist {
+                Distribution::Custom(shares) => (*shares).len(),
+                _ => *config.distribution_count,
+            },
+            Option::None => 0_u32,
+        };
+
+        self.set_distribution(context_id, PackedDistribution { dist_type, dist_param, positions });
+
+        if let Option::Some(dist) = config.distribution {
+            if let Distribution::Custom(shares) = dist {
+                self.store_distribution_shares(context_id, *shares);
+            }
+        }
     }
 
     fn is_entry_fee_set(self: @T, context_id: u64) -> bool {
@@ -247,5 +329,61 @@ pub impl EntryFeeStoreImpl<T, +Store<T>, +Drop<T>> of EntryFeeStoreTrait<T> {
 
     fn get_extension(self: @T, context_id: u64) -> ContractAddress {
         self.get_extension_address(context_id)
+    }
+
+    fn store_distribution_shares(ref self: T, context_id: u64, shares: Span<u16>) {
+        if shares.len() == 0 {
+            return;
+        }
+
+        let mut current_slot: u8 = 0;
+        let mut packed_shares = CustomSharesImpl::new();
+
+        let mut i: u32 = 0;
+        for share in shares {
+            let slot_index: u8 = (i / DISTRIBUTION_SHARES_PER_SLOT.into()).try_into().unwrap();
+            let index_in_slot: u8 = (i % DISTRIBUTION_SHARES_PER_SLOT.into()).try_into().unwrap();
+
+            if slot_index != current_slot && i > 0 {
+                self.set_distribution_shares_packed(context_id, current_slot, packed_shares);
+                packed_shares = CustomSharesImpl::new();
+                current_slot = slot_index;
+            }
+
+            packed_shares.set_share(index_in_slot, *share);
+            i += 1;
+        }
+
+        self.set_distribution_shares_packed(context_id, current_slot, packed_shares);
+    }
+
+    fn get_custom_share_at(self: @T, context_id: u64, position: u32) -> u16 {
+        let (slot_index, index_in_slot) = calculate_slot_position(position - 1);
+        self.get_distribution_shares_packed(context_id, slot_index).get_share(index_in_slot)
+    }
+
+    fn get_distribution_shares(self: @T, context_id: u64, count: u32) -> Array<u16> {
+        let mut shares = ArrayTrait::new();
+        if count == 0 {
+            return shares;
+        }
+
+        let mut current_slot: u8 = 0;
+        let mut packed_shares = CustomSharesImpl::new();
+
+        let mut i: u32 = 0;
+        while i < count {
+            let slot_index: u8 = (i / DISTRIBUTION_SHARES_PER_SLOT.into()).try_into().unwrap();
+            let index_in_slot: u8 = (i % DISTRIBUTION_SHARES_PER_SLOT.into()).try_into().unwrap();
+
+            if slot_index != current_slot || i == 0 {
+                packed_shares = self.get_distribution_shares_packed(context_id, slot_index);
+                current_slot = slot_index;
+            }
+
+            shares.append(packed_shares.get_share(index_in_slot));
+            i += 1;
+        }
+        shares
     }
 }

--- a/packages/metagame/src/entry_fee/store.cairo
+++ b/packages/metagame/src/entry_fee/store.cairo
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+use game_components_utilities::distribution::packed_shares::CustomShares;
+use game_components_utilities::distribution::structs::PackedDistribution;
 use starknet::ContractAddress;
 use crate::entry_fee::structs::PackedAdditionalShares;
 
@@ -23,4 +25,14 @@ pub trait Store<T> {
     fn get_extension_config_len(self: @T, context_id: u64) -> u64;
     fn get_extension_config_at(self: @T, context_id: u64, index: u64) -> felt252;
     fn push_extension_config(ref self: T, context_id: u64, value: felt252);
+    /// Packed custom distribution shares for slot `slot` (15 `u16` per slot).
+    /// The number of shares is sourced from `get_distribution().positions` —
+    /// no separate count is stored here.
+    fn get_distribution_shares_packed(self: @T, context_id: u64, slot: u8) -> CustomShares;
+    fn set_distribution_shares_packed(ref self: T, context_id: u64, slot: u8, shares: CustomShares);
+    /// Distribution shape (type tag + weight + paid-places count) for the
+    /// entry-fee pool payout. Unset unless the context configured a payout
+    /// distribution.
+    fn get_distribution(self: @T, context_id: u64) -> PackedDistribution;
+    fn set_distribution(ref self: T, context_id: u64, distribution: PackedDistribution);
 }

--- a/packages/metagame/src/entry_fee/tests.cairo
+++ b/packages/metagame/src/entry_fee/tests.cairo
@@ -1,5 +1,6 @@
 pub mod mocks;
 mod test_claim_types;
+mod test_distribution_shares;
 mod test_entry_fee_store;
 mod test_packed_additional_shares;
 mod test_storage_gas;

--- a/packages/metagame/src/entry_fee/tests/mocks/entry_fee_mock.cairo
+++ b/packages/metagame/src/entry_fee/tests/mocks/entry_fee_mock.cairo
@@ -70,4 +70,14 @@ pub mod EntryFeeMock {
     fn get_extension_address(self: @ContractState, context_id: u64) -> ContractAddress {
         self.entry_fee.get_extension_address(context_id)
     }
+
+    #[external(v0)]
+    fn store_distribution_shares(ref self: ContractState, context_id: u64, shares: Span<u16>) {
+        self.entry_fee._store_distribution_shares(context_id, shares);
+    }
+
+    #[external(v0)]
+    fn get_distribution_shares(self: @ContractState, context_id: u64, count: u32) -> Array<u16> {
+        self.entry_fee._get_distribution_shares(context_id, count)
+    }
 }

--- a/packages/metagame/src/entry_fee/tests/test_claim_types.cairo
+++ b/packages/metagame/src/entry_fee/tests/test_claim_types.cairo
@@ -32,6 +32,8 @@ fn setup_entry_fee_with_additional_shares(mock: IEntryFeeMockDispatcher) {
                 AdditionalShare { recipient: make_address(0xA2), share_bps: 100 },
             ]
                 .span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);

--- a/packages/metagame/src/entry_fee/tests/test_distribution_shares.cairo
+++ b/packages/metagame/src/entry_fee/tests/test_distribution_shares.cairo
@@ -1,0 +1,103 @@
+/// Tests for packed-storage custom distribution shares on EntryFeeComponent.
+///
+/// Validates that `store_distribution_shares` / `get_distribution_shares`
+/// round-trip arrays correctly, including across slot boundaries (>15 shares).
+/// Callers pass the share count to `get_distribution_shares`; there is no
+/// separate count storage — in production the count is sourced from the
+/// sibling `PackedDistribution.positions`.
+
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+
+#[starknet::interface]
+trait IEntryFeeDistShares<TContractState> {
+    fn store_distribution_shares(ref self: TContractState, context_id: u64, shares: Span<u16>);
+    fn get_distribution_shares(self: @TContractState, context_id: u64, count: u32) -> Array<u16>;
+}
+
+fn deploy_mock() -> IEntryFeeDistSharesDispatcher {
+    let contract_class = declare("EntryFeeMock").expect('declare failed').contract_class();
+    let (contract_address, _) = contract_class.deploy(@array![]).expect('deploy failed');
+    IEntryFeeDistSharesDispatcher { contract_address }
+}
+
+#[test]
+fn test_distribution_shares_empty_by_default() {
+    let mock = deploy_mock();
+    let shares = mock.get_distribution_shares(42, 0);
+    assert!(shares.len() == 0, "Default shares should be empty");
+}
+
+#[test]
+fn test_distribution_shares_single_slot_roundtrip() {
+    let mock = deploy_mock();
+
+    let input = array![6000_u16, 3000_u16, 1000_u16];
+    mock.store_distribution_shares(1, input.span());
+
+    let out = mock.get_distribution_shares(1, 3);
+    assert!(out.len() == 3, "Length");
+    assert!(*out.at(0) == 6000, "Share 0");
+    assert!(*out.at(1) == 3000, "Share 1");
+    assert!(*out.at(2) == 1000, "Share 2");
+}
+
+#[test]
+fn test_distribution_shares_full_slot_roundtrip() {
+    let mock = deploy_mock();
+
+    // Exactly 15 shares = 1 slot
+    let input = array![
+        1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16, 7_u16, 8_u16, 9_u16, 10_u16, 11_u16, 12_u16,
+        13_u16, 14_u16, 15_u16,
+    ];
+    mock.store_distribution_shares(2, input.span());
+
+    let out = mock.get_distribution_shares(2, 15);
+    assert!(out.len() == 15, "Length");
+    let mut i: u32 = 0;
+    while i < 15 {
+        let expected: u16 = (i + 1).try_into().unwrap();
+        assert!(*out.at(i) == expected, "Share mismatch");
+        i += 1;
+    }
+}
+
+#[test]
+fn test_distribution_shares_multi_slot_roundtrip() {
+    let mock = deploy_mock();
+
+    // 50 shares = ceil(50/15) = 4 slots
+    let mut input: Array<u16> = ArrayTrait::new();
+    let mut i: u16 = 0;
+    while i < 50 {
+        input.append(100 + i);
+        i += 1;
+    }
+    mock.store_distribution_shares(3, input.span());
+
+    let out = mock.get_distribution_shares(3, 50);
+    assert!(out.len() == 50, "Length");
+    let mut j: u32 = 0;
+    while j < 50 {
+        let expected: u16 = (100 + j).try_into().unwrap();
+        assert!(*out.at(j) == expected, "Share mismatch");
+        j += 1;
+    }
+}
+
+#[test]
+fn test_distribution_shares_isolated_per_context() {
+    let mock = deploy_mock();
+
+    mock.store_distribution_shares(10, array![5000_u16, 3000_u16, 2000_u16].span());
+    mock.store_distribution_shares(11, array![7000_u16, 3000_u16].span());
+
+    let a = mock.get_distribution_shares(10, 3);
+    let b = mock.get_distribution_shares(11, 2);
+
+    assert!(a.len() == 3, "Context 10 length");
+    assert!(*a.at(0) == 5000 && *a.at(1) == 3000 && *a.at(2) == 2000, "Context 10 values");
+
+    assert!(b.len() == 2, "Context 11 length");
+    assert!(*b.at(0) == 7000 && *b.at(1) == 3000, "Context 11 values");
+}

--- a/packages/metagame/src/entry_fee/tests/test_entry_fee_store.cairo
+++ b/packages/metagame/src/entry_fee/tests/test_entry_fee_store.cairo
@@ -86,6 +86,8 @@ fn test_set_entry_fee_succeeds_when_not_set() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     // First call should succeed (is_entry_fee_set returns false)
@@ -108,6 +110,8 @@ fn test_set_entry_fee_panics_when_already_set() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -120,6 +124,8 @@ fn test_set_entry_fee_panics_when_already_set() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee2);
@@ -136,6 +142,8 @@ fn test_set_entry_fee_different_contexts_succeed() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee1);
@@ -147,6 +155,8 @@ fn test_set_entry_fee_different_contexts_succeed() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     // Different context should succeed (is_entry_fee_set returns false for context 2)
@@ -178,6 +188,8 @@ fn test_get_entry_fee_with_both_shares_nonzero() {
             game_creator_share: Option::Some(1500), // 15%
             refund_share: Option::Some(750), // 7.5%
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(42, entry_fee);
@@ -216,6 +228,8 @@ fn test_get_entry_fee_no_additional_but_gc_and_refund() {
             game_creator_share: Option::Some(5000), // 50%
             refund_share: Option::Some(2500), // 25%
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(10, entry_fee);
@@ -243,6 +257,8 @@ fn test_additional_shares_crossing_slot_boundary_17() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -273,6 +289,8 @@ fn test_additional_shares_crossing_slot_boundary_20() {
             game_creator_share: Option::Some(100),
             refund_share: Option::Some(50),
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -301,6 +319,8 @@ fn test_additional_shares_crossing_slot_boundary_32() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -329,6 +349,8 @@ fn test_get_entry_fee_with_cross_slot_shares() {
             game_creator_share: Option::Some(2000),
             refund_share: Option::Some(1000),
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(5, entry_fee);
@@ -356,6 +378,8 @@ fn test_game_creator_is_claimed_default_false() {
             game_creator_share: Option::Some(500),
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -373,6 +397,8 @@ fn test_game_creator_set_claimed() {
             game_creator_share: Option::Some(500),
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -392,6 +418,8 @@ fn test_game_creator_claim_preserves_other_data() {
             game_creator_share: Option::Some(1000),
             refund_share: Option::Some(500),
             additional_shares: create_additional_shares(2).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -472,6 +500,8 @@ fn test_additional_share_claim_across_slots() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(20).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -734,6 +764,8 @@ fn test_mixed_claim_types_on_same_context() {
             game_creator_share: Option::Some(500),
             refund_share: Option::Some(300),
             additional_shares: create_additional_shares(3).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -778,6 +810,8 @@ fn test_get_additional_shares_empty() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -802,6 +836,8 @@ fn test_exactly_16_shares_full_slot() {
             game_creator_share: Option::Some(1000),
             refund_share: Option::Some(500),
             additional_shares: shares.span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);

--- a/packages/metagame/src/entry_fee/tests/test_storage_gas.cairo
+++ b/packages/metagame/src/entry_fee/tests/test_storage_gas.cairo
@@ -70,6 +70,8 @@ fn test_storage_gas_1_additional_share() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(1).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -95,6 +97,8 @@ fn test_storage_gas_4_additional_shares() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(4).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -120,6 +124,8 @@ fn test_storage_gas_8_additional_shares() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(8).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -146,6 +152,8 @@ fn test_storage_gas_16_additional_shares() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(16).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -170,6 +178,8 @@ fn test_storage_gas_claim_status() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(8).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -207,6 +217,8 @@ fn test_storage_gas_claim_multiple_shares() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: create_additional_shares(16).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
 
@@ -256,6 +268,8 @@ fn test_get_entry_fee_roundtrip_with_shares() {
             game_creator_share: Option::Some(1000), // 10%
             refund_share: Option::Some(500), // 5%
             additional_shares: create_additional_shares(2).span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);
@@ -279,6 +293,8 @@ fn test_get_entry_fee_roundtrip_no_shares() {
             game_creator_share: Option::None,
             refund_share: Option::None,
             additional_shares: array![].span(),
+            distribution: Option::None,
+            distribution_count: 0,
         },
     );
     mock.set_entry_fee(1, entry_fee);

--- a/packages/metagame/src/prize.cairo
+++ b/packages/metagame/src/prize.cairo
@@ -4,10 +4,5 @@ pub mod prize_store;
 pub mod store;
 pub mod structs;
 
-// Libs (pure logic)
-pub mod libs {
-    pub mod share_math;
-}
-
 #[cfg(test)]
 mod tests;

--- a/packages/metagame/src/prize/structs.cairo
+++ b/packages/metagame/src/prize/structs.cairo
@@ -3,18 +3,19 @@ pub use game_components_interfaces::distribution::Distribution;
 pub use game_components_interfaces::prize::{
     ERC20Data, ERC721Data, Prize, PrizeConfig, PrizeData, PrizeType, TokenTypeData,
 };
+// Re-export CustomShares machinery from utilities so existing consumers that
+// import from `crate::prize::structs` continue to work.
+pub use game_components_utilities::distribution::packed_shares::{
+    CustomShares, CustomSharesImpl, CustomSharesTrait, SHARES_PER_SLOT as CUSTOM_SHARES_PER_SLOT,
+};
 use starknet::ContractAddress;
 use starknet::storage_access::StorePacking;
-use crate::prize::libs::share_math::{SHARES_PER_SLOT, get_packed_share, set_packed_share};
 
 /// NonZero<u128> constants for DivRem-based unpacking.
 mod nz128 {
     pub const TWO_POW_8: NonZero<u128> = 0x100;
     pub const TWO_POW_16: NonZero<u128> = 0x10000;
 }
-
-// Re-export SHARES_PER_SLOT as CUSTOM_SHARES_PER_SLOT for backward compatibility
-pub use crate::prize::libs::share_math::SHARES_PER_SLOT as CUSTOM_SHARES_PER_SLOT;
 
 // Payout type constants for storage
 pub const PAYOUT_TYPE_POSITION: u8 = 0;
@@ -215,66 +216,6 @@ pub impl StoredPrizeImpl of StoredPrizeTrait {
             token_type,
             sponsor_address: self.sponsor_address,
         }
-    }
-}
-
-/// Custom shares - stores up to 15 u16 shares in a single felt252
-/// Each share = 16 bits, Layout: [share0(16)] | [share1(16)] | ... | [share14(16)] = 240 bits
-/// This reduces storage operations from N reads to ceil(N/15) reads
-#[derive(Copy, Drop, Serde, starknet::Store)]
-pub struct CustomShares {
-    pub packed: felt252,
-}
-
-/// Helper functions for packing/unpacking custom shares
-#[generate_trait]
-pub impl CustomSharesImpl of CustomSharesTrait {
-    /// Create an empty packed shares struct
-    fn new() -> CustomShares {
-        CustomShares { packed: 0 }
-    }
-
-    /// Get a single share from the packed value at the given index (0-14)
-    fn get_share(self: @CustomShares, index: u8) -> u16 {
-        get_packed_share((*self.packed).into(), index)
-    }
-
-    /// Set a single share in the packed value at the given index (0-14)
-    fn set_share(ref self: CustomShares, index: u8, share: u16) {
-        let new_packed = set_packed_share(self.packed.into(), index, share);
-        self.packed = new_packed.try_into().unwrap();
-    }
-
-    /// Pack an array of shares (up to 15) into a CustomShares
-    fn from_array(shares: Span<u16>) -> CustomShares {
-        let mut packed = Self::new();
-        let len: u32 = if shares.len() > SHARES_PER_SLOT.into() {
-            SHARES_PER_SLOT.into()
-        } else {
-            shares.len()
-        };
-        let mut i: u32 = 0;
-        while i < len {
-            packed.set_share(i.try_into().unwrap(), *shares.at(i));
-            i += 1;
-        }
-        packed
-    }
-
-    /// Unpack shares to an array (returns shares up to count)
-    fn to_array(self: @CustomShares, count: u8) -> Array<u16> {
-        let mut result = ArrayTrait::new();
-        let len: u8 = if count > SHARES_PER_SLOT {
-            SHARES_PER_SLOT
-        } else {
-            count
-        };
-        let mut i: u8 = 0;
-        while i < len {
-            result.append(self.get_share(i));
-            i += 1;
-        }
-        result
     }
 }
 

--- a/packages/utilities/src/distribution.cairo
+++ b/packages/utilities/src/distribution.cairo
@@ -1,2 +1,3 @@
 pub mod calculator;
+pub mod packed_shares;
 pub mod structs;

--- a/packages/utilities/src/distribution/packed_shares.cairo
+++ b/packages/utilities/src/distribution/packed_shares.cairo
@@ -1,14 +1,26 @@
-//! Pure mathematical functions for share calculations and bit packing
-//! These functions operate only on inputs without any storage access
+// SPDX-License-Identifier: BUSL-1.1
 
-/// Number of custom shares (u16) packed per storage slot
-/// Each share = 16 bits, felt252 = 252 bits, so we can fit 15 shares per slot (15 * 16 = 240 bits)
+//! Packed storage for dynamic-length `u16` share arrays.
+//!
+//! A single `felt252` slot holds up to `SHARES_PER_SLOT` (15) shares, each
+//! occupying 16 bits. Multi-slot arrays are stored as
+//! `Map<(key, slot_index: u8), CustomShares>` in the consuming component,
+//! paired with a length counter. This yields ~15x fewer storage ops than a
+//! plain `Vec<u16>` for typical payout-distribution sizes.
+//!
+//! This module is storage-agnostic: it exposes the pure packing math and the
+//! `CustomShares` wrapper. Components wire up their own `Map` + length
+//! counter.
+
+/// Number of `u16` shares packed per `felt252` storage slot.
+/// Each share = 16 bits; felt252 = 252 bits; 15 * 16 = 240 bits fits.
 pub const SHARES_PER_SLOT: u8 = 15;
 
 const MASK_16: u256 = 0xFFFF;
 
-/// Power of 2 for u256 (optimized for multiples of 16 used in share packing)
-/// Returns 2^exp for common exponents used in 16-bit share packing
+/// 2^exp for the exponents used in 16-bit share packing (0, 16, 32, ..., 224).
+/// Returns an iterative fallback for unexpected inputs, but valid callers only
+/// use index * 16 where index is 0..14.
 pub fn pow_2_u256_16(exp: u256) -> u256 {
     if exp == 0 {
         return 1;
@@ -55,7 +67,6 @@ pub fn pow_2_u256_16(exp: u256) -> u256 {
     if exp == 224 {
         return 0x100000000000000000000000000000000000000000000000000000000;
     }
-    // Fallback (should not be reached for valid indices 0-14)
     let mut result: u256 = 1;
     let mut i: u256 = 0;
     while i < exp {
@@ -65,8 +76,7 @@ pub fn pow_2_u256_16(exp: u256) -> u256 {
     result
 }
 
-/// Extract a 16-bit share from a packed u256 value at the given index
-/// index must be 0-14 (15 shares per slot)
+/// Extract the 16-bit share at `index` (0..14) from a packed `u256`.
 pub fn get_packed_share(packed: u256, index: u8) -> u16 {
     assert!(index < SHARES_PER_SLOT, "Index out of bounds");
     let shift: u256 = (index.into() * 16_u32).into();
@@ -75,9 +85,8 @@ pub fn get_packed_share(packed: u256, index: u8) -> u16 {
     value.try_into().unwrap()
 }
 
-/// Set a 16-bit share in a packed u256 value at the given index
-/// index must be 0-14 (15 shares per slot)
-/// Returns the new packed value
+/// Overwrite the 16-bit share at `index` (0..14) and return the new packed
+/// value.
 pub fn set_packed_share(packed: u256, index: u8, share: u16) -> u256 {
     assert!(index < SHARES_PER_SLOT, "Index out of bounds");
     let shift: u256 = (index.into() * 16_u32).into();
@@ -87,15 +96,14 @@ pub fn set_packed_share(packed: u256, index: u8, share: u16) -> u256 {
     (packed & ~mask) | shifted_value
 }
 
-/// Calculate the slot index and position within slot for a given share index
-/// Returns (slot_index, index_within_slot)
+/// Given a logical share index, return `(slot_index, index_within_slot)`.
 pub fn calculate_slot_position(share_index: u32) -> (u8, u8) {
     let slot_index: u8 = (share_index / SHARES_PER_SLOT.into()).try_into().unwrap();
     let index_in_slot: u8 = (share_index % SHARES_PER_SLOT.into()).try_into().unwrap();
     (slot_index, index_in_slot)
 }
 
-/// Calculate the number of storage slots needed for a given number of shares
+/// Number of storage slots required for a dense array of `share_count` shares.
 pub fn calculate_slots_needed(share_count: u32) -> u8 {
     if share_count == 0 {
         return 0;
@@ -104,11 +112,68 @@ pub fn calculate_slots_needed(share_count: u32) -> u8 {
     slots.try_into().unwrap()
 }
 
+/// Packed holder for up to `SHARES_PER_SLOT` (15) `u16` shares in a single
+/// `felt252` storage slot.
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub struct CustomShares {
+    pub packed: felt252,
+}
+
+#[generate_trait]
+pub impl CustomSharesImpl of CustomSharesTrait {
+    fn new() -> CustomShares {
+        CustomShares { packed: 0 }
+    }
+
+    fn get_share(self: @CustomShares, index: u8) -> u16 {
+        get_packed_share((*self.packed).into(), index)
+    }
+
+    fn set_share(ref self: CustomShares, index: u8, share: u16) {
+        let new_packed = set_packed_share(self.packed.into(), index, share);
+        self.packed = new_packed.try_into().unwrap();
+    }
+
+    /// Pack up to `SHARES_PER_SLOT` shares from `shares` into a new slot.
+    /// Shares past the first `SHARES_PER_SLOT` are ignored; callers split
+    /// longer arrays across multiple slots themselves.
+    fn from_array(shares: Span<u16>) -> CustomShares {
+        let mut packed = Self::new();
+        let len: u32 = if shares.len() > SHARES_PER_SLOT.into() {
+            SHARES_PER_SLOT.into()
+        } else {
+            shares.len()
+        };
+        let mut i: u32 = 0;
+        while i < len {
+            packed.set_share(i.try_into().unwrap(), *shares.at(i));
+            i += 1;
+        }
+        packed
+    }
+
+    /// Unpack the first `count` shares (clamped to `SHARES_PER_SLOT`).
+    fn to_array(self: @CustomShares, count: u8) -> Array<u16> {
+        let mut result = ArrayTrait::new();
+        let len: u8 = if count > SHARES_PER_SLOT {
+            SHARES_PER_SLOT
+        } else {
+            count
+        };
+        let mut i: u8 = 0;
+        while i < len {
+            result.append(self.get_share(i));
+            i += 1;
+        }
+        result
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        SHARES_PER_SLOT, calculate_slot_position, calculate_slots_needed, get_packed_share,
-        pow_2_u256_16, set_packed_share,
+        CustomSharesImpl, CustomSharesTrait, SHARES_PER_SLOT, calculate_slot_position,
+        calculate_slots_needed, get_packed_share, pow_2_u256_16, set_packed_share,
     };
 
     #[test]
@@ -122,17 +187,13 @@ mod tests {
     #[test]
     fn test_get_set_packed_share() {
         let packed: u256 = 0;
-
-        // Set share at index 0
         let packed = set_packed_share(packed, 0, 1000);
         assert!(get_packed_share(packed, 0) == 1000, "share 0 mismatch");
 
-        // Set share at index 5
         let packed = set_packed_share(packed, 5, 5000);
         assert!(get_packed_share(packed, 5) == 5000, "share 5 mismatch");
         assert!(get_packed_share(packed, 0) == 1000, "share 0 should be unchanged");
 
-        // Set share at index 14 (max)
         let packed = set_packed_share(packed, 14, 14000);
         assert!(get_packed_share(packed, 14) == 14000, "share 14 mismatch");
     }
@@ -165,5 +226,34 @@ mod tests {
     #[test]
     fn test_shares_per_slot_constant() {
         assert!(SHARES_PER_SLOT == 15, "SHARES_PER_SLOT should be 15");
+    }
+
+    #[test]
+    fn test_custom_shares_from_to_array() {
+        let shares = array![100_u16, 200_u16, 300_u16, 400_u16, 500_u16];
+        let packed = CustomSharesImpl::from_array(shares.span());
+        let decoded = packed.to_array(5);
+        assert!(decoded.len() == 5, "decoded length mismatch");
+        assert!(*decoded.at(0) == 100, "share 0");
+        assert!(*decoded.at(1) == 200, "share 1");
+        assert!(*decoded.at(2) == 300, "share 2");
+        assert!(*decoded.at(3) == 400, "share 3");
+        assert!(*decoded.at(4) == 500, "share 4");
+    }
+
+    #[test]
+    fn test_custom_shares_full_slot_roundtrip() {
+        let shares = array![
+            1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16, 7_u16, 8_u16, 9_u16, 10_u16, 11_u16, 12_u16,
+            13_u16, 14_u16, 15_u16,
+        ];
+        let packed = CustomSharesImpl::from_array(shares.span());
+        let decoded = packed.to_array(15);
+        let mut i: u32 = 0;
+        while i < 15 {
+            let expected: u16 = (i + 1).try_into().unwrap();
+            assert!(*decoded.at(i) == expected, "share mismatch");
+            i += 1;
+        }
     }
 }

--- a/packages/utilities/src/distribution/structs.cairo
+++ b/packages/utilities/src/distribution/structs.cairo
@@ -5,50 +5,105 @@ use starknet::storage_access::StorePacking;
 /// Basis points constant: 10000 = 100%
 pub const BASIS_POINTS: u16 = 10000;
 
-// Distribution type constants for storage packing
+// Distribution type tag used by `PackedDistribution` to record which
+// `Distribution` variant a context was configured with. There is no blanket
+// `StorePacking<Distribution>` impl — a single-felt252 pack is lossy for
+// `Distribution::Custom(Span<u16>)`, so callers persist the custom shares
+// out-of-band via `packed_shares::CustomShares` and store the type tag +
+// scalar params via `PackedDistribution`.
 pub const DIST_TYPE_LINEAR: u8 = 0;
 pub const DIST_TYPE_EXPONENTIAL: u8 = 1;
 pub const DIST_TYPE_UNIFORM: u8 = 2;
 pub const DIST_TYPE_CUSTOM: u8 = 3;
 
-// Constants for packing/unpacking Distribution
+// Constants for PackedDistribution bit-packing.
 const TWO_POW_8: u128 = 0x100; // 2^8
-const MASK_8: u128 = 0xFF; // 8 bits of 1s
-const MASK_16: u128 = 0xFFFF; // 16 bits of 1s
+const TWO_POW_24: u128 = 0x1000000; // 2^24
+const MASK_8: u128 = 0xFF;
+const MASK_16: u128 = 0xFFFF;
+const MASK_32: u128 = 0xFFFFFFFF;
 
-/// StorePacking implementation for Distribution (without positions count)
-/// Packs into felt252: dist_type(8) | dist_param(16)
-/// Total: 24 bits fits in felt252 (251 bits)
-/// Custom distributions are stored as type+empty param, with shares stored separately
-pub impl DistributionStorePacking of StorePacking<Distribution, felt252> {
-    fn pack(value: Distribution) -> felt252 {
-        let (dist_type, dist_param) = match value {
-            Distribution::Linear(weight) => (DIST_TYPE_LINEAR, weight),
-            Distribution::Exponential(weight) => (DIST_TYPE_EXPONENTIAL, weight),
-            Distribution::Uniform => (DIST_TYPE_UNIFORM, 0_u16),
-            Distribution::Custom(_) => (DIST_TYPE_CUSTOM, 0_u16),
-        };
+/// Distribution configuration packed into a single `felt252`.
+///
+/// Layout: `dist_type(8) | dist_param(16) | positions(32)` = 56 bits.
+///
+/// - `dist_type` — one of `DIST_TYPE_LINEAR` / `DIST_TYPE_EXPONENTIAL` /
+///   `DIST_TYPE_UNIFORM` / `DIST_TYPE_CUSTOM`.
+/// - `dist_param` — weight for `Linear`/`Exponential`; 0 otherwise.
+/// - `positions` — fixed paid-places count. `0` means "dynamic — use the
+///   actual leaderboard size at payout time". For `Custom`, this always
+///   equals the backing shares array length.
+///
+/// This struct is the packed companion to `Distribution`; consumers
+/// rehydrate the full enum by pairing it with a `CustomShares` Vec when
+/// `dist_type == DIST_TYPE_CUSTOM`. Custom distributions enforce
+/// `sum(shares) == available_share` at creation, so there is no rounding
+/// remainder ("dust") to track at claim time.
+#[derive(Copy, Drop, Serde)]
+pub struct PackedDistribution {
+    pub dist_type: u8,
+    pub dist_param: u16,
+    pub positions: u32,
+}
 
-        // Layout: dist_type(8) | dist_param(16)
-        let packed: felt252 = dist_type.into() + (dist_param.into() * TWO_POW_8.into());
+pub impl PackedDistributionStorePacking of StorePacking<PackedDistribution, felt252> {
+    fn pack(value: PackedDistribution) -> felt252 {
+        let packed: felt252 = value.dist_type.into()
+            + (value.dist_param.into() * TWO_POW_8.into())
+            + (value.positions.into() * TWO_POW_24.into());
         packed
     }
 
-    fn unpack(value: felt252) -> Distribution {
+    fn unpack(value: felt252) -> PackedDistribution {
         let value_u128: u128 = value.try_into().unwrap();
 
         let dist_type: u8 = (value_u128 & MASK_8).try_into().unwrap();
         let dist_param: u16 = ((value_u128 / TWO_POW_8) & MASK_16).try_into().unwrap();
+        let positions: u32 = ((value_u128 / TWO_POW_24) & MASK_32).try_into().unwrap();
 
-        if dist_type == DIST_TYPE_LINEAR {
-            Distribution::Linear(dist_param)
-        } else if dist_type == DIST_TYPE_EXPONENTIAL {
-            Distribution::Exponential(dist_param)
-        } else if dist_type == DIST_TYPE_UNIFORM {
-            Distribution::Uniform
-        } else {
-            // Custom - shares must be loaded from separate storage
-            Distribution::Custom(array![].span())
-        }
+        PackedDistribution { dist_type, dist_param, positions }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DIST_TYPE_EXPONENTIAL, DIST_TYPE_LINEAR, PackedDistribution, PackedDistributionStorePacking,
+    };
+
+    #[test]
+    fn test_packed_distribution_roundtrip() {
+        let original = PackedDistribution {
+            dist_type: DIST_TYPE_EXPONENTIAL, dist_param: 15, positions: 0,
+        };
+        let packed = PackedDistributionStorePacking::pack(original);
+        let unpacked = PackedDistributionStorePacking::unpack(packed);
+        assert!(unpacked.dist_type == DIST_TYPE_EXPONENTIAL, "dist_type");
+        assert!(unpacked.dist_param == 15, "dist_param");
+        assert!(unpacked.positions == 0, "positions");
+    }
+
+    #[test]
+    fn test_packed_distribution_with_positions() {
+        let original = PackedDistribution {
+            dist_type: DIST_TYPE_LINEAR, dist_param: 10, positions: 5,
+        };
+        let packed = PackedDistributionStorePacking::pack(original);
+        let unpacked = PackedDistributionStorePacking::unpack(packed);
+        assert!(unpacked.dist_type == DIST_TYPE_LINEAR, "dist_type");
+        assert!(unpacked.dist_param == 10, "dist_param");
+        assert!(unpacked.positions == 5, "positions");
+    }
+
+    #[test]
+    fn test_packed_distribution_max_values() {
+        let original = PackedDistribution {
+            dist_type: 255, dist_param: 65535, positions: 4294967295,
+        };
+        let packed = PackedDistributionStorePacking::pack(original);
+        let unpacked = PackedDistributionStorePacking::unpack(packed);
+        assert!(unpacked.dist_type == 255, "dist_type max");
+        assert!(unpacked.dist_param == 65535, "dist_param max");
+        assert!(unpacked.positions == 4294967295, "positions max");
     }
 }


### PR DESCRIPTION
## Summary

- Makes `Distribution::Custom(Span<u16>)` work end-to-end in `EntryFeeComponent` — previously accepted at the API but silently dropped on write and rehydrated as an empty span.
- Moves `CustomShares` + share-packing math out of `metagame::prize` into `utilities::distribution::packed_shares` so entry-fee and prize paths share the same packing primitive (15 u16 per felt252).
- Adds `PackedDistribution` (dist_type + dist_param + positions) with `StorePacking` to `utilities::distribution` and a companion `EntryFee_distribution` map + `EntryFee_distribution_shares_packed` out-of-band storage on the component.
- Extends `EntryFeeConfig` in `interfaces::entry_fee` with `distribution: Option<Distribution>` and `distribution_count: u32`. `set_entry_fee_config` now persists the full distribution (including Custom shares) and `get_entry_fee` rehydrates it.
- Exposes `_get_custom_share_at(context_id, position)` for O(1) claim paths that only need one share. `get_entry_fee` returns `Custom(empty_span)` by design so the generic path isn't forced to do the O(N/15) reconstruction — UI views call `_get_distribution_shares(id, count)` explicitly.

## Breaking change

`EntryFeeConfig` gained two required fields. Existing consumers need to add `distribution: Option::None, distribution_count: 0` to every struct literal. All in-repo call sites are updated in this PR (test helpers + mocks + existing test suites).

## Test plan

- [x] `scarb build` clean across utilities, interfaces, metagame.
- [x] `snforge test` full metagame suite: **415 passing** (includes 5 new `test_distribution_shares` round-trip tests covering empty default, single-slot, full-15-share, 50-share multi-slot, and per-context isolation).
- [x] `snforge test` utilities suite: **236 passing** (includes moved packed-shares tests).
- [x] Prize module still passes — sponsored Custom prizes use the re-exported `CustomShares` via `pub use` so consumers importing from `crate::prize::structs` keep working.

## Downstream

Budokan PR that consumes this lives at (link to be added) — it swaps Budokan's own `Map<u64, PackedDistribution>` storage for the component-owned version and uses the new fast path. Tagging a release against this branch before merging the Budokan PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom payout distribution configurations in entry fee settings, enabling flexible position-based prize distribution shapes.

* **Tests**
  * Added comprehensive tests for payout distribution storage and retrieval mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->