### PR TITLE
feat: bump metagame_extensions to v0.1.4 (context-owner namespacing)

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -41,7 +41,7 @@ openzeppelin_introspection = { git = "https://github.com/OpenZeppelin/cairo-cont
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 openzeppelin_interfaces = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts.git", tag = "v4.0.1" }
-metagame_extensions_interfaces = { git = "https://github.com/Provable-Games/metagame_extensions.git", tag = "v0.1.3" }
+metagame_extensions_interfaces = { git = "https://github.com/Provable-Games/metagame_extensions.git", tag = "v0.1.4" }
 
 [dependencies]
 starknet.workspace = true

--- a/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
@@ -7,7 +7,7 @@ use metagame_extensions_interfaces::entry_requirement_extension::{
 };
 use openzeppelin_interfaces::erc721::{IERC721Dispatcher, IERC721DispatcherTrait, IERC721_ID};
 use openzeppelin_interfaces::introspection::{ISRC5Dispatcher, ISRC5DispatcherTrait};
-use starknet::{ContractAddress, get_caller_address};
+use starknet::{ContractAddress, get_caller_address, get_contract_address};
 use crate::entry_requirement::entry_requirement::entry_requirement;
 use crate::entry_requirement::store::Store;
 use crate::entry_requirement::structs::{
@@ -142,9 +142,11 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                     contract_address: extension_config.address,
                 };
                 let caller_address = get_caller_address();
+                let context_owner = get_contract_address();
                 let display_extension_address: felt252 = extension_config.address.into();
                 assert!(
-                    extension_dispatcher.valid_entry(context_id, caller_address, qualification),
+                    extension_dispatcher
+                        .valid_entry(context_owner, context_id, caller_address, qualification),
                     "EntryRequirement: Invalid entry according to extension {}",
                     display_extension_address,
                 );
@@ -195,6 +197,7 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                 };
                 let display_extension_address: felt252 = extension_address.into();
                 let caller_address = get_caller_address();
+                let context_owner = get_contract_address();
 
                 let qualification = match qualifier {
                     QualificationProof::Extension(qual) => qual,
@@ -204,7 +207,7 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                 };
 
                 let entries_left = extension_dispatcher
-                    .entries_left(context_id, caller_address, qualification);
+                    .entries_left(context_owner, context_id, caller_address, qualification);
 
                 match entries_left {
                     Option::Some(entries_left) => {

--- a/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
@@ -20,7 +20,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        bannable: Map<u64, bool>,
+        bannable: Map<(ContractAddress, u64), bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -40,16 +40,21 @@ pub mod AcceptingLimitedEntryValidatorMock {
 
     #[abi(embed_v0)]
     impl EntryValidatorImpl of IEntryRequirementExtension<ContractState> {
-        fn context_owner(self: @ContractState, context_id: u64) -> ContractAddress {
-            self.owner_address.read()
+        fn is_context_registered(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            true
         }
 
-        fn bannable(self: @ContractState, context_id: u64) -> bool {
-            self.bannable.read(context_id)
+        fn bannable(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            self.bannable.read((context_owner, context_id))
         }
 
         fn valid_entry(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,
@@ -59,6 +64,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
 
         fn should_ban(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             game_token_id: felt252,
             current_owner: ContractAddress,
@@ -69,6 +75,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
 
         fn entries_left(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,

--- a/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
@@ -46,9 +46,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
             true
         }
 
-        fn bannable(
-            self: @ContractState, context_owner: ContractAddress, context_id: u64,
-        ) -> bool {
+        fn bannable(self: @ContractState, context_owner: ContractAddress, context_id: u64) -> bool {
             self.bannable.read((context_owner, context_id))
         }
 

--- a/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/accepting_limited_entry_validator_mock.cairo
@@ -8,9 +8,7 @@ pub mod AcceptingLimitedEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
-    };
+    use starknet::storage::{Map, StorageMapReadAccess, StoragePointerWriteAccess};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
@@ -46,9 +46,7 @@ pub mod EntryValidatorMock {
             true
         }
 
-        fn bannable(
-            self: @ContractState, context_owner: ContractAddress, context_id: u64,
-        ) -> bool {
+        fn bannable(self: @ContractState, context_owner: ContractAddress, context_id: u64) -> bool {
             self.bannable.read((context_owner, context_id))
         }
 

--- a/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
@@ -8,9 +8,7 @@ pub mod EntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
-    };
+    use starknet::storage::{Map, StorageMapReadAccess, StoragePointerWriteAccess};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/entry_validator_mock.cairo
@@ -20,7 +20,7 @@ pub mod EntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        bannable: Map<u64, bool>,
+        bannable: Map<(ContractAddress, u64), bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -40,16 +40,21 @@ pub mod EntryValidatorMock {
 
     #[abi(embed_v0)]
     impl EntryValidatorImpl of IEntryRequirementExtension<ContractState> {
-        fn context_owner(self: @ContractState, context_id: u64) -> ContractAddress {
-            self.owner_address.read()
+        fn is_context_registered(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            true
         }
 
-        fn bannable(self: @ContractState, context_id: u64) -> bool {
-            self.bannable.read(context_id)
+        fn bannable(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            self.bannable.read((context_owner, context_id))
         }
 
         fn valid_entry(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,
@@ -59,6 +64,7 @@ pub mod EntryValidatorMock {
 
         fn should_ban(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             game_token_id: felt252,
             current_owner: ContractAddress,
@@ -69,6 +75,7 @@ pub mod EntryValidatorMock {
 
         fn entries_left(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,

--- a/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
@@ -19,7 +19,7 @@ pub mod RejectingEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        bannable: Map<u64, bool>,
+        bannable: Map<(ContractAddress, u64), bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -39,16 +39,21 @@ pub mod RejectingEntryValidatorMock {
 
     #[abi(embed_v0)]
     impl EntryValidatorImpl of IEntryRequirementExtension<ContractState> {
-        fn context_owner(self: @ContractState, context_id: u64) -> ContractAddress {
-            self.owner_address.read()
+        fn is_context_registered(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            true
         }
 
-        fn bannable(self: @ContractState, context_id: u64) -> bool {
-            self.bannable.read(context_id)
+        fn bannable(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            self.bannable.read((context_owner, context_id))
         }
 
         fn valid_entry(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,
@@ -58,6 +63,7 @@ pub mod RejectingEntryValidatorMock {
 
         fn should_ban(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             game_token_id: felt252,
             current_owner: ContractAddress,
@@ -68,6 +74,7 @@ pub mod RejectingEntryValidatorMock {
 
         fn entries_left(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,

--- a/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
@@ -7,9 +7,7 @@ pub mod RejectingEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
-    };
+    use starknet::storage::{Map, StorageMapReadAccess, StoragePointerWriteAccess};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/rejecting_entry_validator_mock.cairo
@@ -45,9 +45,7 @@ pub mod RejectingEntryValidatorMock {
             true
         }
 
-        fn bannable(
-            self: @ContractState, context_owner: ContractAddress, context_id: u64,
-        ) -> bool {
+        fn bannable(self: @ContractState, context_owner: ContractAddress, context_id: u64) -> bool {
             self.bannable.read((context_owner, context_id))
         }
 

--- a/packages/test_common/src/mocks/mock_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_entry_validator.cairo
@@ -46,9 +46,7 @@ pub mod EntryValidatorMock {
             true
         }
 
-        fn bannable(
-            self: @ContractState, context_owner: ContractAddress, context_id: u64,
-        ) -> bool {
+        fn bannable(self: @ContractState, context_owner: ContractAddress, context_id: u64) -> bool {
             self.bannable.read((context_owner, context_id))
         }
 

--- a/packages/test_common/src/mocks/mock_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_entry_validator.cairo
@@ -8,9 +8,7 @@ pub mod EntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
-    };
+    use starknet::storage::{Map, StorageMapReadAccess, StoragePointerWriteAccess};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/test_common/src/mocks/mock_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_entry_validator.cairo
@@ -20,7 +20,7 @@ pub mod EntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        bannable: Map<u64, bool>,
+        bannable: Map<(ContractAddress, u64), bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -40,16 +40,21 @@ pub mod EntryValidatorMock {
 
     #[abi(embed_v0)]
     impl EntryValidatorImpl of IEntryRequirementExtension<ContractState> {
-        fn context_owner(self: @ContractState, context_id: u64) -> ContractAddress {
-            self.owner_address.read()
+        fn is_context_registered(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            true
         }
 
-        fn bannable(self: @ContractState, context_id: u64) -> bool {
-            self.bannable.read(context_id)
+        fn bannable(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            self.bannable.read((context_owner, context_id))
         }
 
         fn valid_entry(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,
@@ -59,6 +64,7 @@ pub mod EntryValidatorMock {
 
         fn should_ban(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             game_token_id: felt252,
             current_owner: ContractAddress,
@@ -69,6 +75,7 @@ pub mod EntryValidatorMock {
 
         fn entries_left(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,

--- a/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
@@ -19,7 +19,7 @@ pub mod RejectingEntryValidatorMock {
     #[storage]
     struct Storage {
         owner_address: ContractAddress,
-        bannable: Map<u64, bool>,
+        bannable: Map<(ContractAddress, u64), bool>,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
     }
@@ -39,16 +39,21 @@ pub mod RejectingEntryValidatorMock {
 
     #[abi(embed_v0)]
     impl EntryValidatorImpl of IEntryRequirementExtension<ContractState> {
-        fn context_owner(self: @ContractState, context_id: u64) -> ContractAddress {
-            self.owner_address.read()
+        fn is_context_registered(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            true
         }
 
-        fn bannable(self: @ContractState, context_id: u64) -> bool {
-            self.bannable.read(context_id)
+        fn bannable(
+            self: @ContractState, context_owner: ContractAddress, context_id: u64,
+        ) -> bool {
+            self.bannable.read((context_owner, context_id))
         }
 
         fn valid_entry(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,
@@ -58,6 +63,7 @@ pub mod RejectingEntryValidatorMock {
 
         fn should_ban(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             game_token_id: felt252,
             current_owner: ContractAddress,
@@ -68,6 +74,7 @@ pub mod RejectingEntryValidatorMock {
 
         fn entries_left(
             self: @ContractState,
+            context_owner: ContractAddress,
             context_id: u64,
             player_address: ContractAddress,
             qualification: Span<felt252>,

--- a/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
@@ -7,9 +7,7 @@ pub mod RejectingEntryValidatorMock {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use starknet::ContractAddress;
-    use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
-    };
+    use starknet::storage::{Map, StorageMapReadAccess, StoragePointerWriteAccess};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 

--- a/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
+++ b/packages/test_common/src/mocks/mock_rejecting_entry_validator.cairo
@@ -45,9 +45,7 @@ pub mod RejectingEntryValidatorMock {
             true
         }
 
-        fn bannable(
-            self: @ContractState, context_owner: ContractAddress, context_id: u64,
-        ) -> bool {
+        fn bannable(self: @ContractState, context_owner: ContractAddress, context_id: u64) -> bool {
             self.bannable.read((context_owner, context_id))
         }
 


### PR DESCRIPTION
## Summary

Bumps `metagame_extensions_interfaces` to the newly-released `v0.1.4`, which namespaces extension storage by `(context_owner, context_id)`. Under the previous model, the first caller to register a `context_id` on an extension contract took permanent ownership — two different consumer contracts could not share the same `context_id` on the same validator.

See **[Provable-Games/metagame_extensions#19](https://github.com/Provable-Games/metagame_extensions/pull/19)** for the full interface change and rationale.

### Interface updates consumed here

- Read methods on `IEntryRequirementExtension` / `IEntryFeeExtension` / `IPrizeExtension` gained a leading `context_owner: ContractAddress` parameter.
- `context_owner(context_id)` was removed; replaced by `is_context_registered(context_owner, context_id) -> bool`.
- Write methods (`add_config`, `add_entry`, `remove_entry`, `set_entry_fee_config`, `pay_entry_fee`, `claim_entry_fee`, `add_prize`, `claim_prize`) are unchanged.

### Changes in this PR

- **`Scarb.toml`** — bump `metagame_extensions_interfaces` from `v0.1.3` to `v0.1.4`.
- **`entry_requirement_store.cairo`** — the two dispatcher read calls (`valid_entry`, `entries_left`) now pass `starknet::get_contract_address()` as the `context_owner`. The metagame contract was the caller at `add_config` time, so it owns the matching namespace on the validator.
- **Mocks** (`metagame/src/entry_requirement/tests/mocks/*.cairo`, `test_common/src/mocks/*.cairo`) — updated to the new interface shape. Added `is_context_registered`, removed `context_owner`, threaded `context_owner` through `bannable` / `valid_entry` / `should_ban` / `entries_left`. Mock storage rekeyed so per-context maps are keyed by `(ContractAddress, u64)`.

## Test plan

- [x] `scarb build` clean
- [x] `scarb fmt --check` clean
- [x] `snforge test --workspace` passes (reported clean locally by the repo owner)
- [ ] Verify no unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entry requirement validation system now tracks context ownership alongside context identification for improved context-dependent validation accuracy.

* **Chores**
  * Updated external dependency version for metagame extensions interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->