### PR TITLE
chore: bump version to v1.1.7

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -17,7 +17,7 @@ version.workspace = true
 edition.workspace = true
 
 [workspace.package]
-version = "1.1.6"
+version = "1.1.7"
 edition = "2024_07"
 cairo-version = "2.16.1"
 authors = ["Provable Games <maintainers@provable.games>"]


### PR DESCRIPTION
## Summary

Bumps workspace version from 1.1.6 to 1.1.7.

v1.1.6 was tagged before the context-owner namespacing changes (#105) merged. v1.1.7 will be cut from the current HEAD so consumers wanting metagame_extensions v0.1.4 interface support have a proper version to depend on.

## Test plan

- [x] `scarb build --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)