### PR TITLE
refactor(registration)!: key flags by token_id, drop entry_id reverse

### DIFF
--- a/packages/interfaces/src/registration.cairo
+++ b/packages/interfaces/src/registration.cairo
@@ -15,8 +15,8 @@ pub trait IRegistration<TState> {
     /// Check if an entry exists at (context_id, entry_id)
     fn entry_exists(self: @TState, context_id: u64, entry_id: u32) -> bool;
 
-    /// Check if an entry is banned
-    fn is_entry_banned(self: @TState, context_id: u64, entry_id: u32) -> bool;
+    /// Check if a token is banned
+    fn is_token_banned(self: @TState, token_id: felt252) -> bool;
 
     /// Get entry count for a context
     fn get_entry_count(self: @TState, context_id: u64) -> u32;

--- a/packages/metagame/src/registration/registration_component.cairo
+++ b/packages/metagame/src/registration/registration_component.cairo
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /// RegistrationComponent handles registration storage and logic for any context.
-/// Entries are keyed by (context_id, entry_id) for direct enumeration. A reverse
-/// index keyed by token_id supports O(1) token-to-entry lookups, since each
-/// token belongs to exactly one context within a component instance.
+/// Entries are keyed by (context_id, entry_id) for direct enumeration. Flags
+/// (has_submitted / is_banned) are keyed directly by token_id, since each
+/// token belongs to exactly one context within a component instance — this
+/// gives consumers O(1) flag access from a token_id without an intermediate
+/// entry_id lookup. A reverse index maps token_id back to its context_id for
+/// the metagame `has_context` interface.
 ///
 /// Storage layout:
 ///   - Registration_token_ids: (context_id, entry_id) -> felt252  (game token ID)
-///   - Registration_flags: (context_id, entry_id) -> u8  (bit 0 = has_submitted, bit 1 = is_banned)
+///   - Registration_flags: token_id -> u8  (bit 0 = has_submitted, bit 1 = is_banned)
 ///   - Registration_entry_counts: context_id -> u32  (next entry_id is count + 1)
 ///   - Registration_token_context: token_id -> u64  (reverse: which context owns this token)
-///   - Registration_token_entry_id: token_id -> u32  (reverse: token's slot within its context)
 ///
 /// Conventions:
-///   - context_id is expected to be >= 1. The reverse-index lookups
-///     (`_get_token_context`, `_get_entry_id_for_token`) treat 0 as
+///   - context_id is expected to be >= 1. `_get_token_context` treats 0 as
 ///     "not registered", so a caller using context_id == 0 cannot
 ///     distinguish a real context-zero registration from an unknown
 ///     token via the reverse index. entry_id is always >= 1 by
@@ -34,14 +35,12 @@ pub mod RegistrationComponent {
     pub struct Storage {
         /// Game token ID keyed by (context_id, entry_id)
         Registration_token_ids: Map<(u64, u32), felt252>,
-        /// Flags keyed by (context_id, entry_id): bit 0 = has_submitted, bit 1 = is_banned
-        Registration_flags: Map<(u64, u32), u8>,
+        /// Flags keyed by token_id: bit 0 = has_submitted, bit 1 = is_banned
+        Registration_flags: Map<felt252, u8>,
         /// Entry count per context
         Registration_entry_counts: Map<u64, u32>,
         /// Reverse: token_id -> context_id (0 if not registered)
         Registration_token_context: Map<felt252, u64>,
-        /// Reverse: token_id -> entry_id within its context (0 if not registered)
-        Registration_token_entry_id: Map<felt252, u32>,
     }
 
     #[event]
@@ -67,14 +66,12 @@ pub mod RegistrationComponent {
             self.Registration_token_ids.entry((context_id, entry_id)).write(token_id);
         }
 
-        fn get_flags(self: @ComponentState<TContractState>, context_id: u64, entry_id: u32) -> u8 {
-            self.Registration_flags.entry((context_id, entry_id)).read()
+        fn get_flags(self: @ComponentState<TContractState>, token_id: felt252) -> u8 {
+            self.Registration_flags.entry(token_id).read()
         }
 
-        fn set_flags(
-            ref self: ComponentState<TContractState>, context_id: u64, entry_id: u32, flags: u8,
-        ) {
-            self.Registration_flags.entry((context_id, entry_id)).write(flags);
+        fn set_flags(ref self: ComponentState<TContractState>, token_id: felt252, flags: u8) {
+            self.Registration_flags.entry(token_id).write(flags);
         }
 
         fn get_entry_count(self: @ComponentState<TContractState>, context_id: u64) -> u32 {
@@ -94,16 +91,6 @@ pub mod RegistrationComponent {
         ) {
             self.Registration_token_context.entry(token_id).write(context_id);
         }
-
-        fn get_token_entry_id(self: @ComponentState<TContractState>, token_id: felt252) -> u32 {
-            self.Registration_token_entry_id.entry(token_id).read()
-        }
-
-        fn set_token_entry_id(
-            ref self: ComponentState<TContractState>, token_id: felt252, entry_id: u32,
-        ) {
-            self.Registration_token_entry_id.entry(token_id).write(entry_id);
-        }
     }
 
     #[embeddable_as(RegistrationImpl)]
@@ -122,10 +109,8 @@ pub mod RegistrationComponent {
             RegistrationStoreTrait::entry_exists(self, context_id, entry_id)
         }
 
-        fn is_entry_banned(
-            self: @ComponentState<TContractState>, context_id: u64, entry_id: u32,
-        ) -> bool {
-            RegistrationStoreTrait::is_entry_banned(self, context_id, entry_id)
+        fn is_token_banned(self: @ComponentState<TContractState>, token_id: felt252) -> bool {
+            RegistrationStoreTrait::is_token_banned(self, token_id)
         }
 
         fn get_entry_count(self: @ComponentState<TContractState>, context_id: u64) -> u32 {
@@ -155,14 +140,12 @@ pub mod RegistrationComponent {
             RegistrationStoreTrait::increment_entry_count(ref self, context_id)
         }
 
-        fn mark_entry_submitted(
-            ref self: ComponentState<TContractState>, context_id: u64, entry_id: u32,
-        ) {
-            RegistrationStoreTrait::mark_entry_submitted(ref self, context_id, entry_id);
+        fn mark_token_submitted(ref self: ComponentState<TContractState>, token_id: felt252) {
+            RegistrationStoreTrait::mark_token_submitted(ref self, token_id);
         }
 
-        fn ban_entry(ref self: ComponentState<TContractState>, context_id: u64, entry_id: u32) {
-            RegistrationStoreTrait::ban_entry(ref self, context_id, entry_id);
+        fn ban_token(ref self: ComponentState<TContractState>, token_id: felt252) {
+            RegistrationStoreTrait::ban_token(ref self, token_id);
         }
 
         fn _entry_exists(
@@ -181,10 +164,12 @@ pub mod RegistrationComponent {
             Store::get_token_context(self, token_id)
         }
 
-        fn _get_entry_id_for_token(
-            self: @ComponentState<TContractState>, token_id: felt252,
-        ) -> u32 {
-            Store::get_token_entry_id(self, token_id)
+        fn _is_token_submitted(self: @ComponentState<TContractState>, token_id: felt252) -> bool {
+            RegistrationStoreTrait::is_token_submitted(self, token_id)
+        }
+
+        fn _is_token_banned(self: @ComponentState<TContractState>, token_id: felt252) -> bool {
+            RegistrationStoreTrait::is_token_banned(self, token_id)
         }
     }
 }

--- a/packages/metagame/src/registration/registration_component.cairo
+++ b/packages/metagame/src/registration/registration_component.cairo
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /// RegistrationComponent handles registration storage and logic for any context.
-/// Entries are keyed by (context_id, entry_id) for direct enumeration. Flags
-/// (has_submitted / is_banned) are keyed directly by token_id, since each
-/// token belongs to exactly one context within a component instance — this
-/// gives consumers O(1) flag access from a token_id without an intermediate
-/// entry_id lookup. A reverse index maps token_id back to its context_id for
-/// the metagame `has_context` interface.
+/// Entries are keyed by (context_id, entry_id) for direct enumeration.
+/// Per-token state (context_id + has_submitted + is_banned) lives in a single
+/// packed felt252 keyed by token_id, giving consumers O(1) state access from a
+/// token without intermediate lookups.
 ///
 /// Storage layout:
 ///   - Registration_token_ids: (context_id, entry_id) -> felt252  (game token ID)
-///   - Registration_flags: token_id -> u8  (bit 0 = has_submitted, bit 1 = is_banned)
 ///   - Registration_entry_counts: context_id -> u32  (next entry_id is count + 1)
-///   - Registration_token_context: token_id -> u64  (reverse: which context owns this token)
+///   - Registration_token_state: token_id -> packed felt252
+///       bits  0..63: context_id (u64) — 0 means "not registered"
+///       bit   64:    has_submitted
+///       bit   65:    is_banned
 ///
 /// Conventions:
 ///   - context_id is expected to be >= 1. `_get_token_context` treats 0 as
@@ -35,12 +35,10 @@ pub mod RegistrationComponent {
     pub struct Storage {
         /// Game token ID keyed by (context_id, entry_id)
         Registration_token_ids: Map<(u64, u32), felt252>,
-        /// Flags keyed by token_id: bit 0 = has_submitted, bit 1 = is_banned
-        Registration_flags: Map<felt252, u8>,
         /// Entry count per context
         Registration_entry_counts: Map<u64, u32>,
-        /// Reverse: token_id -> context_id (0 if not registered)
-        Registration_token_context: Map<felt252, u64>,
+        /// Per-token packed state. See structs.cairo TokenStateStorePacking for layout.
+        Registration_token_state: Map<felt252, felt252>,
     }
 
     #[event]
@@ -66,14 +64,6 @@ pub mod RegistrationComponent {
             self.Registration_token_ids.entry((context_id, entry_id)).write(token_id);
         }
 
-        fn get_flags(self: @ComponentState<TContractState>, token_id: felt252) -> u8 {
-            self.Registration_flags.entry(token_id).read()
-        }
-
-        fn set_flags(ref self: ComponentState<TContractState>, token_id: felt252, flags: u8) {
-            self.Registration_flags.entry(token_id).write(flags);
-        }
-
         fn get_entry_count(self: @ComponentState<TContractState>, context_id: u64) -> u32 {
             self.Registration_entry_counts.entry(context_id).read()
         }
@@ -82,14 +72,16 @@ pub mod RegistrationComponent {
             self.Registration_entry_counts.entry(context_id).write(count);
         }
 
-        fn get_token_context(self: @ComponentState<TContractState>, token_id: felt252) -> u64 {
-            self.Registration_token_context.entry(token_id).read()
+        fn get_token_state_raw(
+            self: @ComponentState<TContractState>, token_id: felt252,
+        ) -> felt252 {
+            self.Registration_token_state.entry(token_id).read()
         }
 
-        fn set_token_context(
-            ref self: ComponentState<TContractState>, token_id: felt252, context_id: u64,
+        fn set_token_state_raw(
+            ref self: ComponentState<TContractState>, token_id: felt252, state: felt252,
         ) {
-            self.Registration_token_context.entry(token_id).write(context_id);
+            self.Registration_token_state.entry(token_id).write(state);
         }
     }
 
@@ -161,7 +153,7 @@ pub mod RegistrationComponent {
         }
 
         fn _get_token_context(self: @ComponentState<TContractState>, token_id: felt252) -> u64 {
-            Store::get_token_context(self, token_id)
+            RegistrationStoreTrait::get_token_context(self, token_id)
         }
 
         fn _is_token_submitted(self: @ComponentState<TContractState>, token_id: felt252) -> bool {

--- a/packages/metagame/src/registration/registration_store.cairo
+++ b/packages/metagame/src/registration/registration_store.cairo
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use game_components_interfaces::registration::Registration;
-use game_components_metagame::registration::registration::registration::{
-    RegistrationOperationsImpl, RegistrationValidationImpl,
-};
+use game_components_metagame::registration::registration::registration::RegistrationValidationImpl;
 use game_components_metagame::registration::store::Store;
+use game_components_metagame::registration::structs::{
+    TokenState, TokenStateStorePacking, unpack_token_context_id, unpack_token_has_submitted,
+    unpack_token_is_banned,
+};
 
 /// Store bridge: composes Store<T> reads with pure lib operations
 pub trait RegistrationStoreTrait<T> {
@@ -14,13 +16,15 @@ pub trait RegistrationStoreTrait<T> {
     fn set_entry(ref self: T, registration: @Registration);
     /// Check if an entry exists (token_id at slot != 0)
     fn entry_exists(self: @T, context_id: u64, entry_id: u32) -> bool;
-    /// Check if a token has submitted (flags-only read)
+    /// Read context_id for a token (0 if not registered)
+    fn get_token_context(self: @T, token_id: felt252) -> u64;
+    /// Check if a token has submitted (per-field unpack — single SLOAD)
     fn is_token_submitted(self: @T, token_id: felt252) -> bool;
-    /// Check if a token is banned (flags-only read)
+    /// Check if a token is banned (per-field unpack — single SLOAD)
     fn is_token_banned(self: @T, token_id: felt252) -> bool;
-    /// Mark a token as having submitted a score (flags-only read/write)
+    /// Mark a token as having submitted a score (RMW on packed slot)
     fn mark_token_submitted(ref self: T, token_id: felt252);
-    /// Ban a token (flags-only read/write)
+    /// Ban a token (RMW on packed slot)
     fn ban_token(ref self: T, token_id: felt252);
     /// Increment entry count and return new count
     fn increment_entry_count(ref self: T, context_id: u64) -> u32;
@@ -31,52 +35,63 @@ pub trait RegistrationStoreTrait<T> {
 pub impl RegistrationStoreImpl<T, +Store<T>, +Drop<T>> of RegistrationStoreTrait<T> {
     fn get_entry(self: @T, context_id: u64, entry_id: u32) -> Registration {
         let game_token_id = self.get_token_id(context_id, entry_id);
-        let flags = self.get_flags(game_token_id);
-        let (has_submitted, is_banned) = RegistrationOperationsImpl::unpack_flags(flags);
-        Registration { context_id, entry_id, game_token_id, has_submitted, is_banned }
+        let packed = self.get_token_state_raw(game_token_id);
+        let state = TokenStateStorePacking::unpack(packed);
+        Registration {
+            context_id,
+            entry_id,
+            game_token_id,
+            has_submitted: state.has_submitted,
+            is_banned: state.is_banned,
+        }
     }
 
     fn set_entry(ref self: T, registration: @Registration) {
         RegistrationValidationImpl::assert_valid_token_id(*registration.game_token_id);
-        // If this slot was previously held by a different token, clear its reverse
-        // mapping so the displaced token no longer claims this slot.
+        // If this slot was previously held by a different token, zero its packed
+        // state so the displaced token no longer claims this slot.
         let prev_token = self.get_token_id(*registration.context_id, *registration.entry_id);
         if prev_token != 0 && prev_token != *registration.game_token_id {
-            self.set_token_context(prev_token, 0);
+            self.set_token_state_raw(prev_token, 0);
         }
         self
             .set_token_id(
                 *registration.context_id, *registration.entry_id, *registration.game_token_id,
             );
-        let flags = RegistrationOperationsImpl::pack_flags(
-            *registration.has_submitted, *registration.is_banned,
-        );
-        self.set_flags(*registration.game_token_id, flags);
-        self.set_token_context(*registration.game_token_id, *registration.context_id);
+        let state = TokenState {
+            context_id: *registration.context_id,
+            has_submitted: *registration.has_submitted,
+            is_banned: *registration.is_banned,
+        };
+        self.set_token_state_raw(*registration.game_token_id, TokenStateStorePacking::pack(state));
     }
 
     fn entry_exists(self: @T, context_id: u64, entry_id: u32) -> bool {
         self.get_token_id(context_id, entry_id) != 0
     }
 
+    fn get_token_context(self: @T, token_id: felt252) -> u64 {
+        unpack_token_context_id(self.get_token_state_raw(token_id))
+    }
+
     fn is_token_submitted(self: @T, token_id: felt252) -> bool {
-        let flags = self.get_flags(token_id);
-        RegistrationOperationsImpl::is_submitted(flags)
+        unpack_token_has_submitted(self.get_token_state_raw(token_id))
     }
 
     fn is_token_banned(self: @T, token_id: felt252) -> bool {
-        let flags = self.get_flags(token_id);
-        RegistrationOperationsImpl::is_banned(flags)
+        unpack_token_is_banned(self.get_token_state_raw(token_id))
     }
 
     fn mark_token_submitted(ref self: T, token_id: felt252) {
-        let flags = self.get_flags(token_id);
-        self.set_flags(token_id, RegistrationOperationsImpl::set_submitted(flags));
+        let mut state = TokenStateStorePacking::unpack(self.get_token_state_raw(token_id));
+        state.has_submitted = true;
+        self.set_token_state_raw(token_id, TokenStateStorePacking::pack(state));
     }
 
     fn ban_token(ref self: T, token_id: felt252) {
-        let flags = self.get_flags(token_id);
-        self.set_flags(token_id, RegistrationOperationsImpl::set_banned(flags));
+        let mut state = TokenStateStorePacking::unpack(self.get_token_state_raw(token_id));
+        state.is_banned = true;
+        self.set_token_state_raw(token_id, TokenStateStorePacking::pack(state));
     }
 
     fn increment_entry_count(ref self: T, context_id: u64) -> u32 {

--- a/packages/metagame/src/registration/registration_store.cairo
+++ b/packages/metagame/src/registration/registration_store.cairo
@@ -12,14 +12,16 @@ pub trait RegistrationStoreTrait<T> {
     fn get_entry(self: @T, context_id: u64, entry_id: u32) -> Registration;
     /// Write a registration entry to storage
     fn set_entry(ref self: T, registration: @Registration);
-    /// Check if an entry exists (token_id != 0)
+    /// Check if an entry exists (token_id at slot != 0)
     fn entry_exists(self: @T, context_id: u64, entry_id: u32) -> bool;
-    /// Check if an entry is banned (flags-only read)
-    fn is_entry_banned(self: @T, context_id: u64, entry_id: u32) -> bool;
-    /// Mark an entry as having submitted a score (flags-only read/write)
-    fn mark_entry_submitted(ref self: T, context_id: u64, entry_id: u32);
-    /// Ban an entry (flags-only read/write)
-    fn ban_entry(ref self: T, context_id: u64, entry_id: u32);
+    /// Check if a token has submitted (flags-only read)
+    fn is_token_submitted(self: @T, token_id: felt252) -> bool;
+    /// Check if a token is banned (flags-only read)
+    fn is_token_banned(self: @T, token_id: felt252) -> bool;
+    /// Mark a token as having submitted a score (flags-only read/write)
+    fn mark_token_submitted(ref self: T, token_id: felt252);
+    /// Ban a token (flags-only read/write)
+    fn ban_token(ref self: T, token_id: felt252);
     /// Increment entry count and return new count
     fn increment_entry_count(ref self: T, context_id: u64) -> u32;
     /// Validate registration for score submission
@@ -29,7 +31,7 @@ pub trait RegistrationStoreTrait<T> {
 pub impl RegistrationStoreImpl<T, +Store<T>, +Drop<T>> of RegistrationStoreTrait<T> {
     fn get_entry(self: @T, context_id: u64, entry_id: u32) -> Registration {
         let game_token_id = self.get_token_id(context_id, entry_id);
-        let flags = self.get_flags(context_id, entry_id);
+        let flags = self.get_flags(game_token_id);
         let (has_submitted, is_banned) = RegistrationOperationsImpl::unpack_flags(flags);
         Registration { context_id, entry_id, game_token_id, has_submitted, is_banned }
     }
@@ -37,11 +39,10 @@ pub impl RegistrationStoreImpl<T, +Store<T>, +Drop<T>> of RegistrationStoreTrait
     fn set_entry(ref self: T, registration: @Registration) {
         RegistrationValidationImpl::assert_valid_token_id(*registration.game_token_id);
         // If this slot was previously held by a different token, clear its reverse
-        // mappings so the displaced token no longer claims this slot via the index.
+        // mapping so the displaced token no longer claims this slot.
         let prev_token = self.get_token_id(*registration.context_id, *registration.entry_id);
         if prev_token != 0 && prev_token != *registration.game_token_id {
             self.set_token_context(prev_token, 0);
-            self.set_token_entry_id(prev_token, 0);
         }
         self
             .set_token_id(
@@ -50,28 +51,32 @@ pub impl RegistrationStoreImpl<T, +Store<T>, +Drop<T>> of RegistrationStoreTrait
         let flags = RegistrationOperationsImpl::pack_flags(
             *registration.has_submitted, *registration.is_banned,
         );
-        self.set_flags(*registration.context_id, *registration.entry_id, flags);
+        self.set_flags(*registration.game_token_id, flags);
         self.set_token_context(*registration.game_token_id, *registration.context_id);
-        self.set_token_entry_id(*registration.game_token_id, *registration.entry_id);
     }
 
     fn entry_exists(self: @T, context_id: u64, entry_id: u32) -> bool {
         self.get_token_id(context_id, entry_id) != 0
     }
 
-    fn is_entry_banned(self: @T, context_id: u64, entry_id: u32) -> bool {
-        let flags = self.get_flags(context_id, entry_id);
+    fn is_token_submitted(self: @T, token_id: felt252) -> bool {
+        let flags = self.get_flags(token_id);
+        RegistrationOperationsImpl::is_submitted(flags)
+    }
+
+    fn is_token_banned(self: @T, token_id: felt252) -> bool {
+        let flags = self.get_flags(token_id);
         RegistrationOperationsImpl::is_banned(flags)
     }
 
-    fn mark_entry_submitted(ref self: T, context_id: u64, entry_id: u32) {
-        let flags = self.get_flags(context_id, entry_id);
-        self.set_flags(context_id, entry_id, RegistrationOperationsImpl::set_submitted(flags));
+    fn mark_token_submitted(ref self: T, token_id: felt252) {
+        let flags = self.get_flags(token_id);
+        self.set_flags(token_id, RegistrationOperationsImpl::set_submitted(flags));
     }
 
-    fn ban_entry(ref self: T, context_id: u64, entry_id: u32) {
-        let flags = self.get_flags(context_id, entry_id);
-        self.set_flags(context_id, entry_id, RegistrationOperationsImpl::set_banned(flags));
+    fn ban_token(ref self: T, token_id: felt252) {
+        let flags = self.get_flags(token_id);
+        self.set_flags(token_id, RegistrationOperationsImpl::set_banned(flags));
     }
 
     fn increment_entry_count(ref self: T, context_id: u64) -> u32 {

--- a/packages/metagame/src/registration/store.cairo
+++ b/packages/metagame/src/registration/store.cairo
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-/// Generic store trait for registration operations
+/// Generic store trait for registration operations.
+///
+/// `token_state` is a single packed felt252 holding context_id (low 64 bits)
+/// plus has_submitted/is_banned flag bits. Bit layout is described in
+/// `structs.cairo`'s `TokenStateStorePacking`. Consumers should use the
+/// per-field unpack helpers in `structs.cairo` rather than rebuilding the
+/// full struct.
 pub trait Store<T> {
     fn get_token_id(self: @T, context_id: u64, entry_id: u32) -> felt252;
     fn set_token_id(ref self: T, context_id: u64, entry_id: u32, token_id: felt252);
-    /// Flags keyed by token_id: bit 0 = has_submitted, bit 1 = is_banned
-    fn get_flags(self: @T, token_id: felt252) -> u8;
-    fn set_flags(ref self: T, token_id: felt252, flags: u8);
     fn get_entry_count(self: @T, context_id: u64) -> u32;
     fn set_entry_count(ref self: T, context_id: u64, count: u32);
-    /// Reverse index: token_id -> context_id (0 if not registered)
-    fn get_token_context(self: @T, token_id: felt252) -> u64;
-    fn set_token_context(ref self: T, token_id: felt252, context_id: u64);
+    /// Packed token state: context_id (low 64 bits) | has_submitted (bit 64) | is_banned (bit 65).
+    /// Returns 0 (= not registered, no flags set) for unknown tokens.
+    fn get_token_state_raw(self: @T, token_id: felt252) -> felt252;
+    fn set_token_state_raw(ref self: T, token_id: felt252, state: felt252);
 }

--- a/packages/metagame/src/registration/store.cairo
+++ b/packages/metagame/src/registration/store.cairo
@@ -4,14 +4,12 @@
 pub trait Store<T> {
     fn get_token_id(self: @T, context_id: u64, entry_id: u32) -> felt252;
     fn set_token_id(ref self: T, context_id: u64, entry_id: u32, token_id: felt252);
-    fn get_flags(self: @T, context_id: u64, entry_id: u32) -> u8;
-    fn set_flags(ref self: T, context_id: u64, entry_id: u32, flags: u8);
+    /// Flags keyed by token_id: bit 0 = has_submitted, bit 1 = is_banned
+    fn get_flags(self: @T, token_id: felt252) -> u8;
+    fn set_flags(ref self: T, token_id: felt252, flags: u8);
     fn get_entry_count(self: @T, context_id: u64) -> u32;
     fn set_entry_count(ref self: T, context_id: u64, count: u32);
     /// Reverse index: token_id -> context_id (0 if not registered)
     fn get_token_context(self: @T, token_id: felt252) -> u64;
     fn set_token_context(ref self: T, token_id: felt252, context_id: u64);
-    /// Reverse index: token_id -> entry_id within its context (0 if not registered)
-    fn get_token_entry_id(self: @T, token_id: felt252) -> u32;
-    fn set_token_entry_id(ref self: T, token_id: felt252, entry_id: u32);
 }

--- a/packages/metagame/src/registration/structs.cairo
+++ b/packages/metagame/src/registration/structs.cairo
@@ -1,10 +1,11 @@
-/// Entry data stored per (context_id, entry_id).
-/// game_token_id != 0 means the entry exists.
-///
-/// StorePacking layout (2 storage slots instead of 3):
-///   Slot 1: game_token_id as felt252 (full 251 bits)
-///   Slot 2: flags as u8 — bit 0 = has_submitted, bit 1 = is_banned
+/// Storage-packed structs for the registration component.
 use starknet::storage_access::StorePacking;
+
+// ----------------------------------------------------------------------------
+// RegistrationEntryData
+// Legacy struct kept for the test_models suite. Production storage uses
+// TokenState below.
+// ----------------------------------------------------------------------------
 
 #[derive(Copy, Drop, Serde)]
 pub struct RegistrationEntryData {
@@ -32,4 +33,72 @@ pub impl RegistrationEntryDataStorePacking of StorePacking<RegistrationEntryData
 
         RegistrationEntryData { game_token_id, has_submitted, is_banned }
     }
+}
+
+// ----------------------------------------------------------------------------
+// TokenState — per-token packed state
+//
+// Replaces the previous separate `Registration_flags` and
+// `Registration_token_context` storage maps with a single packed slot per
+// token, halving the SSTOREs at registration time and letting consumers
+// resolve `(context, flags)` in a single SLOAD.
+//
+// Bit layout in the packed felt252 (low → high):
+//   bits  0..63: context_id (u64)  — 0 means "not registered"
+//   bit   64:    has_submitted
+//   bit   65:    is_banned
+//   bits 66..:  reserved (0)
+// ----------------------------------------------------------------------------
+
+const CONTEXT_ID_MASK: u128 = 0xFFFFFFFFFFFFFFFF; // low 64 bits
+const HAS_SUBMITTED_BIT: u128 = 0x10000000000000000; // bit 64
+const IS_BANNED_BIT: u128 = 0x20000000000000000; // bit 65
+
+#[derive(Copy, Drop, Serde)]
+pub struct TokenState {
+    pub context_id: u64,
+    pub has_submitted: bool,
+    pub is_banned: bool,
+}
+
+pub impl TokenStateStorePacking of StorePacking<TokenState, felt252> {
+    fn pack(value: TokenState) -> felt252 {
+        let mut packed: u128 = value.context_id.into();
+        if value.has_submitted {
+            packed = packed | HAS_SUBMITTED_BIT;
+        }
+        if value.is_banned {
+            packed = packed | IS_BANNED_BIT;
+        }
+        packed.into()
+    }
+
+    fn unpack(value: felt252) -> TokenState {
+        let packed: u128 = value.try_into().unwrap();
+        let context_id: u64 = (packed & CONTEXT_ID_MASK).try_into().unwrap();
+        let has_submitted = (packed & HAS_SUBMITTED_BIT) != 0;
+        let is_banned = (packed & IS_BANNED_BIT) != 0;
+        TokenState { context_id, has_submitted, is_banned }
+    }
+}
+
+/// Extract only context_id from a packed TokenState felt252.
+/// Avoids full unpack when only the context lookup is needed.
+pub fn unpack_token_context_id(packed: felt252) -> u64 {
+    let packed: u128 = packed.try_into().unwrap();
+    (packed & CONTEXT_ID_MASK).try_into().unwrap()
+}
+
+/// Extract only has_submitted from a packed TokenState felt252.
+/// Avoids full unpack when only the flag is needed.
+pub fn unpack_token_has_submitted(packed: felt252) -> bool {
+    let packed: u128 = packed.try_into().unwrap();
+    (packed & HAS_SUBMITTED_BIT) != 0
+}
+
+/// Extract only is_banned from a packed TokenState felt252.
+/// Avoids full unpack when only the flag is needed.
+pub fn unpack_token_is_banned(packed: felt252) -> bool {
+    let packed: u128 = packed.try_into().unwrap();
+    (packed & IS_BANNED_BIT) != 0
 }

--- a/packages/metagame/src/registration/tests/mocks/registration_mock.cairo
+++ b/packages/metagame/src/registration/tests/mocks/registration_mock.cairo
@@ -34,13 +34,13 @@ pub mod RegistrationMock {
     }
 
     #[external(v0)]
-    fn mark_entry_submitted(ref self: ContractState, context_id: u64, entry_id: u32) {
-        self.registration.mark_entry_submitted(context_id, entry_id);
+    fn mark_token_submitted(ref self: ContractState, token_id: felt252) {
+        self.registration.mark_token_submitted(token_id);
     }
 
     #[external(v0)]
-    fn ban_entry(ref self: ContractState, context_id: u64, entry_id: u32) {
-        self.registration.ban_entry(context_id, entry_id);
+    fn ban_token(ref self: ContractState, token_id: felt252) {
+        self.registration.ban_token(token_id);
     }
 
     #[external(v0)]
@@ -56,7 +56,7 @@ pub mod RegistrationMock {
     }
 
     #[external(v0)]
-    fn get_entry_id_for_token(self: @ContractState, token_id: felt252) -> u32 {
-        self.registration._get_entry_id_for_token(token_id)
+    fn is_token_submitted(self: @ContractState, token_id: felt252) -> bool {
+        self.registration._is_token_submitted(token_id)
     }
 }

--- a/packages/metagame/src/registration/tests/test_registration_component.cairo
+++ b/packages/metagame/src/registration/tests/test_registration_component.cairo
@@ -6,18 +6,18 @@ trait IRegistrationMock<TContractState> {
     // From IRegistration (component embedded)
     fn get_entry(self: @TContractState, context_id: u64, entry_id: u32) -> Registration;
     fn entry_exists(self: @TContractState, context_id: u64, entry_id: u32) -> bool;
-    fn is_entry_banned(self: @TContractState, context_id: u64, entry_id: u32) -> bool;
+    fn is_token_banned(self: @TContractState, token_id: felt252) -> bool;
     fn get_entry_count(self: @TContractState, context_id: u64) -> u32;
     // From mock externals (exposing internal trait for tests)
     fn set_entry(ref self: TContractState, registration: Registration);
     fn increment_entry_count(ref self: TContractState, context_id: u64) -> u32;
-    fn mark_entry_submitted(ref self: TContractState, context_id: u64, entry_id: u32);
-    fn ban_entry(ref self: TContractState, context_id: u64, entry_id: u32);
+    fn mark_token_submitted(ref self: TContractState, token_id: felt252);
+    fn ban_token(ref self: TContractState, token_id: felt252);
     fn assert_valid_for_submission(
         self: @TContractState, registration: Registration, context_id: u64,
     );
     fn get_token_context(self: @TContractState, token_id: felt252) -> u64;
-    fn get_entry_id_for_token(self: @TContractState, token_id: felt252) -> u32;
+    fn is_token_submitted(self: @TContractState, token_id: felt252) -> bool;
 }
 
 fn deploy_mock() -> IRegistrationMockDispatcher {
@@ -86,60 +86,63 @@ fn test_set_entry_zero_token_id_panics() {
 }
 
 // ============================================================================
-// is_entry_banned
+// is_token_banned
 // ============================================================================
 
 #[test]
-fn test_is_entry_banned_default_false() {
+fn test_is_token_banned_default_false() {
     let mock = deploy_mock();
-    let banned = mock.is_entry_banned(1, 1);
+    let banned = mock.is_token_banned(0xDEAD);
     assert!(!banned, "default is_banned should be false");
 }
 
 #[test]
-fn test_ban_entry() {
+fn test_ban_token() {
     let mock = deploy_mock();
     let context_id: u64 = 10;
     let entry_id: u32 = 1;
+    let token_id: felt252 = 0xBBBB;
 
-    let reg = make_registration(context_id, entry_id, 0xBBBB, false, false);
+    let reg = make_registration(context_id, entry_id, token_id, false, false);
     mock.set_entry(reg);
 
-    assert!(!mock.is_entry_banned(context_id, entry_id), "should not be banned initially");
+    assert!(!mock.is_token_banned(token_id), "should not be banned initially");
 
-    mock.ban_entry(context_id, entry_id);
+    mock.ban_token(token_id);
 
-    assert!(mock.is_entry_banned(context_id, entry_id), "should be banned after ban call");
+    assert!(mock.is_token_banned(token_id), "should be banned after ban call");
 
-    // Verify other fields are preserved
+    // Verify other fields are preserved (round-trip via get_entry)
     let retrieved = mock.get_entry(context_id, entry_id);
-    assert!(retrieved.game_token_id == 0xBBBB, "game_token_id should be preserved after ban");
+    assert!(retrieved.game_token_id == token_id, "game_token_id should be preserved after ban");
     assert!(!retrieved.has_submitted, "has_submitted should be preserved after ban");
+    assert!(retrieved.is_banned, "is_banned should reflect through get_entry");
 }
 
 // ============================================================================
-// mark_entry_submitted
+// mark_token_submitted
 // ============================================================================
 
 #[test]
-fn test_mark_entry_submitted() {
+fn test_mark_token_submitted() {
     let mock = deploy_mock();
     let context_id: u64 = 20;
     let entry_id: u32 = 2;
+    let token_id: felt252 = 0xCCCC;
 
-    let reg = make_registration(context_id, entry_id, 0xCCCC, false, false);
+    let reg = make_registration(context_id, entry_id, token_id, false, false);
     mock.set_entry(reg);
 
-    let before = mock.get_entry(context_id, entry_id);
-    assert!(!before.has_submitted, "should not be submitted initially");
+    assert!(!mock.is_token_submitted(token_id), "should not be submitted initially");
 
-    mock.mark_entry_submitted(context_id, entry_id);
+    mock.mark_token_submitted(token_id);
 
+    assert!(mock.is_token_submitted(token_id), "should be submitted after mark");
+
+    // Verify other fields are preserved (round-trip via get_entry)
     let after = mock.get_entry(context_id, entry_id);
-    assert!(after.has_submitted, "should be submitted after mark");
-
-    // Verify other fields are preserved
-    assert!(after.game_token_id == 0xCCCC, "game_token_id should be preserved");
+    assert!(after.has_submitted, "has_submitted should reflect through get_entry");
+    assert!(after.game_token_id == token_id, "game_token_id should be preserved");
     assert!(!after.is_banned, "is_banned should be preserved");
 }
 
@@ -290,10 +293,8 @@ fn test_overwrite_entry() {
 
     // New token resolves to the slot via the reverse index.
     assert!(mock.get_token_context(0x8888) == context_id, "new token context");
-    assert!(mock.get_entry_id_for_token(0x8888) == entry_id, "new token entry_id");
-    // Previous token's reverse mappings must be cleared so it no longer claims the slot.
+    // Previous token's reverse mapping must be cleared so it no longer claims the slot.
     assert!(mock.get_token_context(0x7777) == 0, "old token context should be cleared");
-    assert!(mock.get_entry_id_for_token(0x7777) == 0, "old token entry_id should be cleared");
 }
 
 // ============================================================================
@@ -305,17 +306,18 @@ fn test_ban_then_mark_submitted() {
     let mock = deploy_mock();
     let context_id: u64 = 50;
     let entry_id: u32 = 1;
+    let token_id: felt252 = 0x9999;
 
-    let reg = make_registration(context_id, entry_id, 0x9999, false, false);
+    let reg = make_registration(context_id, entry_id, token_id, false, false);
     mock.set_entry(reg);
 
-    mock.ban_entry(context_id, entry_id);
-    mock.mark_entry_submitted(context_id, entry_id);
+    mock.ban_token(token_id);
+    mock.mark_token_submitted(token_id);
 
     let retrieved = mock.get_entry(context_id, entry_id);
     assert!(retrieved.is_banned, "should be banned");
     assert!(retrieved.has_submitted, "should be submitted");
-    assert!(retrieved.game_token_id == 0x9999, "game_token_id should be preserved");
+    assert!(retrieved.game_token_id == token_id, "game_token_id should be preserved");
 }
 
 // ============================================================================
@@ -383,18 +385,17 @@ fn test_enumerate_entries() {
 }
 
 // ============================================================================
-// Reverse lookups: token_id -> context_id / entry_id
+// Reverse lookup: token_id -> context_id
 // ============================================================================
 
 #[test]
-fn test_token_reverse_lookups_default_zero() {
+fn test_token_reverse_lookup_default_zero() {
     let mock = deploy_mock();
     assert!(mock.get_token_context(0xDEAD) == 0, "default token_context should be 0");
-    assert!(mock.get_entry_id_for_token(0xDEAD) == 0, "default entry_id_for_token should be 0");
 }
 
 #[test]
-fn test_token_reverse_lookups_after_set_entry() {
+fn test_token_reverse_lookup_after_set_entry() {
     let mock = deploy_mock();
     let context_id: u64 = 7;
     let entry_id: u32 = 3;
@@ -404,11 +405,10 @@ fn test_token_reverse_lookups_after_set_entry() {
     mock.set_entry(reg);
 
     assert!(mock.get_token_context(token_id) == context_id, "token_context mismatch");
-    assert!(mock.get_entry_id_for_token(token_id) == entry_id, "entry_id_for_token mismatch");
 }
 
 #[test]
-fn test_token_reverse_lookups_independent_tokens() {
+fn test_token_reverse_lookup_independent_tokens() {
     let mock = deploy_mock();
 
     let reg_a = make_registration(1, 1, 0xAAA, false, false);
@@ -417,7 +417,29 @@ fn test_token_reverse_lookups_independent_tokens() {
     mock.set_entry(reg_b);
 
     assert!(mock.get_token_context(0xAAA) == 1, "token A context");
-    assert!(mock.get_entry_id_for_token(0xAAA) == 1, "token A entry_id");
     assert!(mock.get_token_context(0xBBB) == 2, "token B context");
-    assert!(mock.get_entry_id_for_token(0xBBB) == 5, "token B entry_id");
+}
+
+// ============================================================================
+// Token-keyed flag isolation: flags are scoped to token, not context+entry
+// ============================================================================
+
+#[test]
+fn test_token_flags_are_independent_per_token() {
+    // Two different tokens at the same (context, entry_id) coords across two
+    // distinct contexts should not bleed flags into each other.
+    let mock = deploy_mock();
+
+    let reg_a = make_registration(1, 1, 0xA, false, false);
+    let reg_b = make_registration(2, 1, 0xB, false, false);
+    mock.set_entry(reg_a);
+    mock.set_entry(reg_b);
+
+    mock.mark_token_submitted(0xA);
+    mock.ban_token(0xB);
+
+    assert!(mock.is_token_submitted(0xA), "A submitted");
+    assert!(!mock.is_token_banned(0xA), "A not banned");
+    assert!(!mock.is_token_submitted(0xB), "B not submitted");
+    assert!(mock.is_token_banned(0xB), "B banned");
 }


### PR DESCRIPTION
## Summary

Second pass on the registration component. PR #107 added a token → entry_id reverse index so consumers could resolve a token's slot in O(1). This PR observes that the *only* reason consumers need entry_id after the lookup is because \`Registration_flags\` is keyed by \`(context_id, entry_id)\`. Re-keying the flags map directly by \`token_id\` collapses the two-hop \`token → entry_id → flags\` chain into one hop and makes the entry_id reverse redundant.

### Changes

**Storage**
- ❌ \`Registration_token_entry_id: Map<felt252, u32>\` — deleted
- 🔁 \`Registration_flags: Map<(u64, u32), u8>\` → \`Map<felt252, u8>\`
- ✅ \`Registration_token_ids\`, \`Registration_token_context\`, \`Registration_entry_counts\` — unchanged

**Public \`IRegistration\` trait (BREAKING)**
- \`is_entry_banned(context_id, entry_id) -> bool\` → \`is_token_banned(token_id) -> bool\`
- \`get_entry\`, \`entry_exists\`, \`get_entry_count\` unchanged

**Internal trait**
- DROP \`_get_entry_id_for_token\`, \`mark_entry_submitted(c,e)\`, \`ban_entry(c,e)\`
- ADD \`mark_token_submitted(token_id)\`, \`ban_token(token_id)\`, \`_is_token_submitted(token_id)\`, \`_is_token_banned(token_id)\`
- KEEP \`_get_token_context(token_id)\`

The new \`_is_token_submitted\` / \`_is_token_banned\` helpers let bokendo's \`_is_token_completed\` shrink from 3 storage hops to 1.

### Why

Net per-consumer wins:
- **−1 SSTORE per registration** (entry_id reverse map writes gone from \`set_entry\`)
- **−1 SLOAD per submit/ban/refund** (token → flags is now direct)
- **Less component bytecode** embedded into every consumer that embeds \`RegistrationImpl\` — material for budokan, which is currently ~71 felts over the 81920-felt CASM deploy limit even after PR #107's first-pass migration.

### Indexing / data considerations

Verified by grepping consumer indexers and clients:

- **Indexer schemas are token-keyed already**: budokan PK = \`(tournament_id, game_token_id)\`, bokendo unique = \`(player_address, quest_id)\`. \`entry_number\` is informational, not a key — so structural compatibility is preserved.
- **No client code calls \`is_entry_banned\` or \`get_entry\` directly** — only generated ABIs reference them; safe to rename.
- **One downstream consequence**: contracts currently emit \`entry_number\` on register/submit/ban events, and indexers upsert it on every event. After this redesign, contracts can no longer cheaply derive \`entry_id\` from \`token_id\` at submit/ban time. Consumers should:
  - Pass \`entry_number: 0\` at submit/ban event sites (still emit it correctly at register time, where \`entry_id\` is fresh from \`increment_entry_count\`).
  - Drop \`entryNumber\` from the indexer's \`onConflictDoUpdate\` SET clause so submit/ban events don't overwrite the value persisted at register time.

This affects the budokan and bokendo migrations (PRs to follow). No on-chain data migration is needed — both contracts will be redeployed fresh.

### Test plan

- [x] \`snforge test test_registration\` — 24/24 pass (added \`test_token_flags_are_independent_per_token\` to lock down the new key isolation)
- [x] Full metagame test suite green (per local run)
- [x] \`scarb fmt --check --workspace\` clean
- [x] \`scarb build\` clean

### Release

- Cut **v1.2.0** after merge — this is a breaking trait change.

### Follow-ups

- Force-push budokan #223 and bokendo #34 onto this redesigned API once the new tag exists. Both diffs get *smaller* than they were against PR #107's API (one less indirection per call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored registration system APIs to transition from entry-based to token-based operations
  * Optimized registration storage architecture by consolidating multiple state fields into a single efficient packed-state model
  * Updated test infrastructure to align with new token-centric API design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->