### PR TITLE
perf(entry-requirement): drop redundant entries_left cross-call

### DIFF
--- a/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
@@ -183,6 +183,13 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
         }
     }
 
+    /// Track a successful entry against the configured limit.
+    ///
+    /// For extension-typed requirements this is a no-op: extensions enforce both eligibility
+    /// and remaining-entry quota inside their own `valid_entry` (already called by
+    /// `validate_qualification`). The framework deliberately does NOT make a second
+    /// `entries_left` cross-contract call here — it would walk the same on-chain state a
+    /// second time. See `IEntryRequirementExtension` docs for the contract.
     fn update_qualification_entries(
         ref self: T,
         context_id: u64,
@@ -190,13 +197,7 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
         entry_requirement: EntryRequirement,
     ) {
         match entry_requirement.entry_requirement_type {
-            EntryRequirementType::extension(_) => {
-                // Extensions enforce both eligibility and remaining-entry quota inside
-                // their own `valid_entry` (called from `validate_qualification`). The
-                // framework no longer makes a redundant `entries_left` cross-contract
-                // call here — it would walk the same on-chain state a second time.
-                // See IEntryRequirementExtension docs for the contract.
-            },
+            EntryRequirementType::extension(_) => {},
             _ => {
                 let entry_limit = entry_requirement.entry_limit;
                 if entry_limit != 0 {

--- a/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
@@ -190,35 +190,12 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
         entry_requirement: EntryRequirement,
     ) {
         match entry_requirement.entry_requirement_type {
-            EntryRequirementType::extension(extension_config) => {
-                let extension_address = extension_config.address;
-                let extension_dispatcher = IEntryRequirementExtensionDispatcher {
-                    contract_address: extension_address,
-                };
-                let display_extension_address: felt252 = extension_address.into();
-                let caller_address = get_caller_address();
-                let context_owner = get_contract_address();
-
-                let qualification = match qualifier {
-                    QualificationProof::Extension(qual) => qual,
-                    _ => panic!(
-                        "EntryRequirement: Provided qualification proof is not of type 'Extension'",
-                    ),
-                };
-
-                let entries_left = extension_dispatcher
-                    .entries_left(context_owner, context_id, caller_address, qualification);
-
-                match entries_left {
-                    Option::Some(entries_left) => {
-                        assert!(
-                            entries_left > 0,
-                            "EntryRequirement: No entries left according to extension {}",
-                            display_extension_address,
-                        );
-                    },
-                    Option::None => {},
-                }
+            EntryRequirementType::extension(_) => {
+                // Extensions enforce both eligibility and remaining-entry quota inside
+                // their own `valid_entry` (called from `validate_qualification`). The
+                // framework no longer makes a redundant `entries_left` cross-contract
+                // call here — it would walk the same on-chain state a second time.
+                // See IEntryRequirementExtension docs for the contract.
             },
             _ => {
                 let entry_limit = entry_requirement.entry_limit;

--- a/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
@@ -639,9 +639,11 @@ fn deploy_accepting_limited_entry_validator_mock(owner: ContractAddress) -> Cont
 // ============================================================================
 
 #[test]
-fn test_update_qualification_entries_extension_none_entries_left() {
-    // EntryValidatorMock returns Option::None from entries_left
-    // This means no limit check - should succeed silently
+fn test_update_qualification_entries_extension_is_noop() {
+    // The framework no longer cross-checks the extension's `entries_left` here — extensions
+    // enforce both eligibility and remaining-entry quota inside their own `valid_entry`.
+    // `update_qualification_entries` must therefore complete silently for any extension
+    // requirement, regardless of what the extension would have reported.
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
     let validator_addr = deploy_entry_validator_mock(caller);
@@ -657,7 +659,6 @@ fn test_update_qualification_entries_extension_none_entries_left() {
     snforge_std::cheat_caller_address(
         mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
     );
-    // Should not panic - entries_left returns None (no limit)
     mock
         .update_qualification_entries(
             context_id, QualificationProof::Extension(array![].span()), req,
@@ -665,36 +666,9 @@ fn test_update_qualification_entries_extension_none_entries_left() {
 }
 
 #[test]
-fn test_update_qualification_entries_extension_some_entries_remaining() {
-    // AcceptingLimitedEntryValidatorMock returns Option::Some(5)
-    // entries_left > 0 - should succeed
-    let mock = deploy_entry_requirement_mock();
-    let caller = make_address(0x555);
-    let validator_addr = deploy_accepting_limited_entry_validator_mock(caller);
-    let context_id: u64 = 81;
-
-    let req = EntryRequirement {
-        entry_limit: 10,
-        entry_requirement_type: EntryRequirementType::extension(
-            ExtensionConfig { address: validator_addr, config: array![].span() },
-        ),
-    };
-
-    snforge_std::cheat_caller_address(
-        mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
-    );
-    // Should not panic - entries_left returns Some(5) which is > 0
-    mock
-        .update_qualification_entries(
-            context_id, QualificationProof::Extension(array![].span()), req,
-        );
-}
-
-#[test]
-#[should_panic(expected: "EntryRequirement: No entries left according to extension")]
-fn test_update_qualification_entries_extension_zero_entries_left() {
-    // RejectingEntryValidatorMock returns Option::Some(0)
-    // entries_left == 0 - should panic
+fn test_update_qualification_entries_extension_noop_even_when_extension_would_reject() {
+    // Same as above with a rejecting/zero-entries-left mock. Pre-change this would have
+    // panicked with "No entries left"; post-change the framework never asks the extension.
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
     let validator_addr = deploy_rejecting_entry_validator_mock(caller);
@@ -717,10 +691,11 @@ fn test_update_qualification_entries_extension_zero_entries_left() {
 }
 
 #[test]
-#[should_panic(
-    expected: "EntryRequirement: Provided qualification proof is not of type 'Extension'",
-)]
-fn test_update_qualification_entries_extension_wrong_proof_type() {
+fn test_update_qualification_entries_extension_accepts_any_proof_type() {
+    // Pre-change the framework destructured the qualifier inside the extension branch and
+    // panicked on a non-Extension proof. Post-change the branch is a no-op, so any proof
+    // shape is accepted (the qualifier is consumed by `validate_qualification`, which runs
+    // earlier in `enter_tournament`).
     let mock = deploy_entry_requirement_mock();
     let caller = make_address(0x555);
     let validator_addr = deploy_entry_validator_mock(caller);
@@ -733,7 +708,9 @@ fn test_update_qualification_entries_extension_wrong_proof_type() {
         ),
     };
 
-    // Pass NFT proof for extension requirement - should panic
+    snforge_std::cheat_caller_address(
+        mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
+    );
     mock
         .update_qualification_entries(
             context_id, QualificationProof::NFT(NFTQualification { token_id: 0x123 }), req,


### PR DESCRIPTION
## Summary

Drops the second cross-contract dispatch into the validator on the entry path. Previously `update_qualification_entries` called the extension's `entries_left` purely to assert `> 0` — but the extension's `valid_entry` (already invoked from `validate_qualification`) is contractually required to enforce that. For validators with expensive view paths, this was duplicating the work end-to-end.

The new `IEntryRequirementExtension` contract: `valid_entry` MUST enforce both eligibility AND remaining-entry quota. The framework trusts that single signal on the entry path. `entries_left` remains as an off-chain view.

Pairs with metagame_extensions PR that:
- Updates the interface docs spelling out the new `valid_entry` requirement.
- Tightens the in-tree validators (merkle / snapshot / tournament) so they enforce quota inside `valid_entry`.
- Refactors the Opus validator to a single trove pass.

## Test changes

Three tests in `test_entry_requirement_component.cairo` covered the dispatcher behavior we just removed:
- `extension_none_entries_left` and `extension_some_entries_remaining` rewritten to `extension_is_noop`.
- `extension_zero_entries_left` (was `should_panic`) → `extension_noop_even_when_extension_would_reject`.
- `extension_wrong_proof_type` (was `should_panic` on qualifier destructuring) → `extension_accepts_any_proof_type`.

## Test plan

- [x] `scarb build --workspace` passes
- [x] `snforge test --package game_components_metagame` passes (418/418)
- [ ] Verify `snforge test --workspace` once metagame_extensions sister PR lands and is tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized entry requirement validation for extension-based entries by removing redundant on-chain eligibility checks. The framework now delegates verification responsibility to extensions, reducing unnecessary cross-contract queries while maintaining security through extension-level validation.

* **Tests**
  * Updated test suite to verify the simplified validation flow for extension-based requirements across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->