### PR TITLE
fix(token): preserve absolute lifecycle.end across mint round-trip

### DIFF
--- a/packages/embeddable_game_standard/src/token/tests/test_additional_coverage.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_additional_coverage.cairo
@@ -600,9 +600,9 @@ fn test_core_token_playability_with_lifecycle() {
             0,
         );
 
-    // Token that ends soon after current time (to test expiry)
-    // end_delay = end - start = (PAST_TIME + 1) - PAST_TIME = 1
-    // lifecycle.end = minted_at + start_delay + end_delay = CURRENT_TIME + 0 + 1 = CURRENT_TIME + 1
+    // Token that ends one second after the current time (to test expiry).
+    // `end` is interpreted as an absolute timestamp, not a duration — so we
+    // pass `CURRENT_TIME + 1` directly rather than `start + 1`.
     let expiring_token = test_contracts
         .test_token
         .mint(
@@ -610,7 +610,7 @@ fn test_core_token_playability_with_lifecycle() {
             Option::None,
             Option::None,
             Option::Some(PAST_TIME),
-            Option::Some(PAST_TIME + 1), // end_delay = 1 second (end - start)
+            Option::Some(CURRENT_TIME + 1),
             Option::None,
             Option::None,
             Option::None,
@@ -646,10 +646,8 @@ fn test_core_token_playability_with_lifecycle() {
 
     // Verify playability at CURRENT_TIME
     assert!(!test_contracts.test_token.is_playable(future_token), "Future token not playable yet");
-    // expiring_token: start_delay=0 (PAST_TIME < CURRENT_TIME), end_delay=1 (end - start)
-    // lifecycle.start = minted_at + start_delay = CURRENT_TIME + 0 = CURRENT_TIME
-    // lifecycle.end = minted_at + start_delay + end_delay = CURRENT_TIME + 0 + 1 = CURRENT_TIME + 1
-    // At CURRENT_TIME: playable (start <= now < end)
+    // expiring_token: start clamped to mint time (since PAST_TIME < CURRENT_TIME),
+    // end = CURRENT_TIME + 1. At CURRENT_TIME: playable (start <= now < end).
     assert!(
         test_contracts.test_token.is_playable(expiring_token),
         "Expiring token should be playable now",

--- a/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
@@ -588,6 +588,104 @@ fn test_mint_with_max_timestamp_values() {
     assert!(metadata.lifecycle.end == end_time, "End time should match");
 }
 
+// Regression: when `start` is in the past (e.g. retroactive mint, late entry
+// into a window that already opened) the packed token cannot represent
+// `lifecycle.start < minted_at`, so the effective start is clamped to mint
+// time. The reconstructed `lifecycle.end` must still equal the caller's
+// requested end, not `mint_time + (end - start)` — which would silently
+// extend the playable window past the cutoff the caller specified.
+#[test]
+fn test_mint_with_start_in_past_clamps_to_mint_time_and_preserves_end() {
+    let test_contracts = setup();
+
+    // Mint mid-way between PAST_TIME and FUTURE_TIME with start=PAST_TIME.
+    let mint_time = CURRENT_TIME;
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, mint_time);
+
+    let token_id = test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(PAST_TIME),
+            Option::Some(FUTURE_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+
+    let metadata = test_contracts.test_token.token_metadata(token_id);
+    assert!(
+        metadata.lifecycle.start == mint_time,
+        "Start should clamp to mint time, got {}",
+        metadata.lifecycle.start,
+    );
+    assert!(
+        metadata.lifecycle.end == FUTURE_TIME,
+        "End should equal caller-specified end ({}), got {}",
+        FUTURE_TIME,
+        metadata.lifecycle.end,
+    );
+
+    stop_cheat_block_timestamp(test_contracts.test_token.contract_address);
+}
+
+// Regression: passing `start = None` (defaults to 0) with an absolute end
+// previously made `end_delay = end - 0`, which both overflowed the 25-bit
+// field for any reasonable timestamp and gave the token the wrong window.
+// With the fix, omitted start is treated as "starts at mint time" and
+// end_delay collapses to `end - mint_time`.
+#[test]
+fn test_mint_with_unset_start_uses_mint_time_as_start() {
+    let test_contracts = setup();
+
+    let mint_time = CURRENT_TIME;
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, mint_time);
+
+    let token_id = test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None, // start unset
+            Option::Some(FUTURE_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+
+    let metadata = test_contracts.test_token.token_metadata(token_id);
+    assert!(
+        metadata.lifecycle.start == mint_time,
+        "Start should default to mint time, got {}",
+        metadata.lifecycle.start,
+    );
+    assert!(
+        metadata.lifecycle.end == FUTURE_TIME,
+        "End should equal caller-specified end ({}), got {}",
+        FUTURE_TIME,
+        metadata.lifecycle.end,
+    );
+
+    stop_cheat_block_timestamp(test_contracts.test_token.contract_address);
+}
+
 #[test]
 fn test_mint_sequential_token_ids() {
     // Verify token IDs are sequential

--- a/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
@@ -782,6 +782,195 @@ fn test_mint_with_zero_length_window_panics() {
         );
 }
 
+// Regression: `Some(0), Some(0)` is the explicit-zero spelling of `None, None`
+// — both go through `unwrap_or(0)` and should produce a no-expiration token.
+// Locks in that the explicit-zero form isn't accidentally rejected by the
+// `end > current_time` guard (it only fires when `end != 0`).
+#[test]
+fn test_mint_with_explicit_zero_start_and_end_is_no_expiration() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    let token_id = test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(0),
+            Option::Some(0),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+
+    let metadata = test_contracts.test_token.token_metadata(token_id);
+    assert!(
+        metadata.lifecycle.end == 0,
+        "End should be 0 (no expiration), got {}",
+        metadata.lifecycle.end,
+    );
+    assert!(
+        metadata.lifecycle.start == CURRENT_TIME,
+        "Start should clamp to mint time, got {}",
+        metadata.lifecycle.start,
+    );
+
+    stop_cheat_block_timestamp(test_contracts.test_token.contract_address);
+}
+
+// Regression: a gated start with no end (`Some(future), None`) must still
+// produce a no-expiration token. Confirms the `end == 0` short-circuit in
+// the assertion fires regardless of what `start` is.
+#[test]
+fn test_mint_with_gated_start_and_no_end_is_no_expiration() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    let token_id = test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(FUTURE_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+
+    let metadata = test_contracts.test_token.token_metadata(token_id);
+    assert!(
+        metadata.lifecycle.start == FUTURE_TIME,
+        "Start should be the gated future time, got {}",
+        metadata.lifecycle.start,
+    );
+    assert!(
+        metadata.lifecycle.end == 0,
+        "End should be 0 (no expiration), got {}",
+        metadata.lifecycle.end,
+    );
+
+    stop_cheat_block_timestamp(test_contracts.test_token.contract_address);
+}
+
+// Regression: `start == end` with both in the past hits the `end >
+// current_time` half of the guard rather than the `end > start` half.
+// Same panic message; locks in that every `start == end` flavor is rejected,
+// not only the future-future variant covered by
+// `test_mint_with_zero_length_window_panics`.
+#[test]
+#[should_panic(expected: "MinigameToken: Lifecycle end must be in the future and after start")]
+fn test_mint_with_equal_start_and_end_in_past_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(PAST_TIME),
+            Option::Some(PAST_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
+// Regression: explicit `Some(past_a), Some(past_b)` (both before mint, with
+// `b > a`) must panic. Same code path as
+// `test_mint_with_end_before_mint_time_panics` but with a non-default
+// `start` — documents that providing an explicit historical start doesn't
+// bypass the `end > current_time` guard.
+#[test]
+#[should_panic(expected: "MinigameToken: Lifecycle end must be in the future and after start")]
+fn test_mint_with_both_start_and_end_in_past_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(PAST_TIME),
+            Option::Some(PAST_TIME + 1),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
+// Regression: `end_delay` is packed into 25 bits (~388 days). A window
+// exceeding the max trips the pack-level assertion, not the lifecycle
+// guard. Pins down the upper bound at which mint stops working at all.
+#[test]
+#[should_panic(expected: "PackedTokenId: end_delay exceeds 25-bit limit")]
+fn test_mint_with_window_exceeding_25_bit_pack_limit_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    // 0x2000000 = 2^25, one over the 25-bit max of 0x1FFFFFF (33,554,431).
+    let over_limit_window: u64 = 0x2000000;
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(CURRENT_TIME),
+            Option::Some(CURRENT_TIME + over_limit_window),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
 #[test]
 fn test_mint_sequential_token_ids() {
     // Verify token IDs are sequential

--- a/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
@@ -686,6 +686,102 @@ fn test_mint_with_unset_start_uses_mint_time_as_start() {
     stop_cheat_block_timestamp(test_contracts.test_token.contract_address);
 }
 
+// Regression: minting with an `end` already past `current_time` would
+// previously slip through and produce `end_delay = 0`, which the storage
+// format silently treats as "no expiration". Must panic instead so caller
+// bugs surface loudly rather than producing an immortal token.
+#[test]
+#[should_panic(expected: "MinigameToken: Lifecycle end must be in the future and after start")]
+fn test_mint_with_end_before_mint_time_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::Some(PAST_TIME), // end already in the past
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
+// Regression: `end == current_time` is the boundary case — the token would
+// expire the instant it's minted, so `end_delay` collapses to 0 and the
+// storage format would interpret it as "no expiration".
+#[test]
+#[should_panic(expected: "MinigameToken: Lifecycle end must be in the future and after start")]
+fn test_mint_with_end_equal_to_mint_time_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::Some(CURRENT_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
+// Regression: `start == end` with both in the future passes `validate()`
+// (which only enforces `start <= end`) and the `end > current_time` half of
+// the assertion, but produces a zero-length window — never playable, and
+// `end_delay = 0` would silently flip the token to "no expiration". Must
+// panic on the conjunctive `end > start` half of the guard.
+#[test]
+#[should_panic(expected: "MinigameToken: Lifecycle end must be in the future and after start")]
+fn test_mint_with_zero_length_window_panics() {
+    let test_contracts = setup();
+
+    start_cheat_block_timestamp(test_contracts.test_token.contract_address, CURRENT_TIME);
+
+    test_contracts
+        .test_token
+        .mint(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::Some(FUTURE_TIME),
+            Option::Some(FUTURE_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+}
+
 #[test]
 fn test_mint_sequential_token_ids() {
     // Verify token IDs are sequential

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -858,14 +858,41 @@ pub mod CoreTokenComponent {
             let lifecycle = token_state::create_lifecycle_with_defaults(start, end);
             lifecycle.validate();
 
-            // Compute delays relative to current time
-            let start_delay: u32 = if lifecycle.start > current_time {
-                (lifecycle.start - current_time).try_into().unwrap()
+            // A non-zero `end` must be in the future at mint time. Otherwise the
+            // packed `end_delay` would collapse to 0 — which the storage format
+            // treats as "no expiration" — silently producing a token that lives
+            // forever instead of one that's already expired (almost certainly a
+            // caller bug).
+            assert!(
+                lifecycle.end == 0 || lifecycle.end > current_time,
+                "MinigameToken: Lifecycle end must be in the future",
+            );
+
+            // Compute delays relative to current time.
+            //
+            // The packed token stores `[minted_at, start_delay, end_delay]` where
+            // both delays are non-negative u32s. That makes
+            // `lifecycle.start >= minted_at` a structural invariant — there is
+            // no representation for a window that opened before the mint.
+            //
+            // When a caller passes `start <= current_time` (e.g. retroactive
+            // mint, late entry into a tournament that already started, or an
+            // unset `start` defaulting to 0), we clamp the effective start to
+            // `current_time` and derive `end_delay` from that clamped value.
+            // Without this, `end_delay = lifecycle.end - lifecycle.start` would
+            // encode the *original* window length, and the reconstructed end
+            // (`minted_at + start_delay + end_delay`) would land at
+            // `mint_time + (end - start)` instead of the caller's intended
+            // `lifecycle.end` — silently extending the playable window past
+            // the cutoff the caller specified.
+            let effective_start = if lifecycle.start > current_time {
+                lifecycle.start
             } else {
-                0
+                current_time
             };
-            let end_delay: u32 = if lifecycle.end > 0 && lifecycle.end > lifecycle.start {
-                (lifecycle.end - lifecycle.start).try_into().unwrap()
+            let start_delay: u32 = (effective_start - current_time).try_into().unwrap();
+            let end_delay: u32 = if lifecycle.end > effective_start {
+                (lifecycle.end - effective_start).try_into().unwrap()
             } else {
                 0
             };

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -858,14 +858,23 @@ pub mod CoreTokenComponent {
             let lifecycle = token_state::create_lifecycle_with_defaults(start, end);
             lifecycle.validate();
 
-            // A non-zero `end` must be in the future at mint time. Otherwise the
-            // packed `end_delay` would collapse to 0 — which the storage format
-            // treats as "no expiration" — silently producing a token that lives
-            // forever instead of one that's already expired (almost certainly a
-            // caller bug).
+            // A non-zero `end` must be strictly after both `current_time` and
+            // `lifecycle.start`. Otherwise the packed `end_delay` collapses to
+            // 0 — which the storage format treats as "no expiration" —
+            // silently producing a token that lives forever. Two failure modes
+            // hit this path:
+            //
+            //   * `end <= current_time` — caller passed a window already in
+            //     the past; `lifecycle.end > effective_start` is false because
+            //     `effective_start >= current_time >= end`.
+            //   * `end == start` (with `start > current_time`) — `validate()`
+            //     allows it, but a zero-length window is never playable
+            //     (`is_playable` requires `start <= now < end`), so the caller
+            //     almost certainly didn't mean to mint an immortal token.
             assert!(
-                lifecycle.end == 0 || lifecycle.end > current_time,
-                "MinigameToken: Lifecycle end must be in the future",
+                lifecycle.end == 0
+                    || (lifecycle.end > current_time && lifecycle.end > lifecycle.start),
+                "MinigameToken: Lifecycle end must be in the future and after start",
             );
 
             // Compute delays relative to current time.


### PR DESCRIPTION
## Summary

The packed token stores `[minted_at, start_delay, end_delay]` where both delays are non-negative `u32`s, so `lifecycle.start >= minted_at` is a structural invariant — there is no representation for a window that opened before mint time.

The mint logic clamped `start_delay` to 0 when `start <= current_time`, but still computed `end_delay = lifecycle.end - lifecycle.start` from the **unclamped** start. The reconstructed `lifecycle.end` therefore landed at `mint_time + (end - start)` instead of the caller's intended `lifecycle.end`, silently extending the token's playable window past the cutoff the caller specified.

### Cases that hit this

| Caller passes | Old behavior | Fixed behavior |
|---|---|---|
| `start = abs_game_start, end = abs_game_end`, mint during live phase (`start < now`) | reconstructed end = `mint_time + (end - start)` (past cutoff) | reconstructed end = `end` ✓ |
| `start = None, end = abs_timestamp` (start defaults to 0) | `end_delay = end - 0` — overflows the 25-bit field, encodes wrong window | reconstructed end = `end` ✓ |
| `end != 0 && end <= current_time` (already expired) | silently `end_delay = 0` → token lives forever | panics with `MinigameToken: Lifecycle end must be in the future` |

### Fix

Clamp `effective_start = max(lifecycle.start, current_time)` and derive `end_delay` from the clamped value. The token's playable window for retroactive/late mints becomes `[mint_time, end]` — which matches reality, since the token didn't exist during the part of the window that already passed. Caller's `end` is preserved exactly, regardless of when the mint happens.

Also added a `lifecycle.end > current_time` precondition (when `end != 0`) so callers fail loudly on already-expired windows instead of getting a silently-immortal token.

### Caller impact

This is a behavior change for callers that were relying on the buggy round-trip:

- Previously, passing `start = past_T, end = past_T + N` and minting at `now` produced a token expiring at `now + N` (duration encoding). After the fix, this panics — the absolute `end` is in the past. Callers that wanted a token playable for `N` seconds from mint should pass `start = None, end = now + N` (or `start = now, end = now + N`).
- Multiple callers in the wider ecosystem (e.g. `budokan` tournament entries, `ticket_booth_component` — which got a similar caller-side fix in [a8efe5b](https://github.com/Provable-Games/game-components/commit/a8efe5b)) had to pre-clamp themselves to work around the broken round-trip. After this fix they no longer need to.

## Test plan

- [x] Existing test `test_core_token_playability_with_lifecycle` updated — it had been documenting the bug (passed `end = PAST_TIME + 1` and asserted the token expired at `mint_time + 1`). Now uses absolute `end = CURRENT_TIME + 1`.
- [x] New regression test `test_mint_with_start_in_past_clamps_to_mint_time_and_preserves_end`: mints with `start = PAST_TIME, end = FUTURE_TIME` mid-window, asserts reconstructed `lifecycle.start == mint_time` and `lifecycle.end == FUTURE_TIME`.
- [x] New regression test `test_mint_with_unset_start_uses_mint_time_as_start`: mints with `start = None, end = FUTURE_TIME`, asserts reconstructed `lifecycle.start == mint_time` and `lifecycle.end == FUTURE_TIME`.
- [ ] CI to run the full `embeddable_game_standard` test suite (local environment OOMs on test build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for token lifecycle edge cases, including scenarios with past start times and unset start times during minting.

* **Bug Fixes**
  * Strengthened lifecycle validation to enforce that non-zero end times are in the future at mint time.
  * Refined delay calculations to properly handle start times in the past, ensuring correct playable window timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->