### PR TITLE
feat(metagame): add merkledrop component

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -203,6 +203,10 @@ jobs:
             module: ticket_booth
             runner: ubuntu-latest-4
             fuzzer_runs: 256
+          - package: game_components_metagame
+            module: merkledrop
+            runner: ubuntu-latest-4
+            fuzzer_runs: 256
           # Economy
           - package: game_components_economy
             module: tokenomics

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -307,6 +307,7 @@ jobs:
             add game_components_metagame entry_fee ubuntu-latest-4 256
             add game_components_metagame prize ubuntu-latest-4 256
             add game_components_metagame ticket_booth ubuntu-latest-4 256
+            add game_components_metagame merkledrop ubuntu-latest-4 256
           fi
           if [ "$NEED_ECONOMY" = "true" ]; then
             add game_components_economy tokenomics ubuntu-latest-4 256

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -42,6 +42,7 @@ openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.gi
 openzeppelin_interfaces = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v3.0.0" }
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts.git", tag = "v4.0.1" }
 metagame_extensions_interfaces = { git = "https://github.com/Provable-Games/metagame_extensions.git", tag = "v0.1.4" }
+alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria.git", tag = "v0.9.0" }
 
 [dependencies]
 starknet.workspace = true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   notify:
     # Must equal package count in .github/workflows/main-ci.yml matrix
     # See AGENTS.md "CI Configuration" section when adding packages
-    after_n_builds: 16
+    after_n_builds: 17
 
 comment:
   layout: "diff, files, header, footer"

--- a/packages/metagame/Scarb.toml
+++ b/packages/metagame/Scarb.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 starknet.workspace = true
 openzeppelin_interfaces.workspace = true
 openzeppelin_introspection.workspace = true
+alexandria_merkle_tree.workspace = true
 game_components_embeddable_game_standard = { path = "../embeddable_game_standard" }
 game_components_interfaces = { path = "../interfaces" }
 game_components_utilities = { path = "../utilities" }

--- a/packages/metagame/src/lib.cairo
+++ b/packages/metagame/src/lib.cairo
@@ -2,6 +2,7 @@ pub mod entry_fee;
 pub mod entry_requirement;
 pub mod gpp;
 pub mod leaderboard;
+pub mod merkledrop;
 pub mod prize;
 pub mod registration;
 pub mod ticket_booth;

--- a/packages/metagame/src/merkledrop.cairo
+++ b/packages/metagame/src/merkledrop.cairo
@@ -1,0 +1,6 @@
+pub mod interfaces;
+pub mod merkledrop_component;
+pub mod signature;
+
+#[cfg(test)]
+mod tests;

--- a/packages/metagame/src/merkledrop/AGENTS.md
+++ b/packages/metagame/src/merkledrop/AGENTS.md
@@ -1,0 +1,41 @@
+## Merkle Drop Module
+
+The `merkledrop` module provides a reusable Starknet component for issuing single-use claims against a merkle-tree commitment, supporting two interchangeable credential paths.
+
+### Features
+
+- On-chain tree construction via alexandria Poseidon merkle tree (operator submits raw leaf data; component computes root, stores it, emits per-leaf proof events).
+- Single-use nullifier per `(root, leaf_hash)` shared across both claim paths.
+- Configurable tree expiry timestamp.
+- Two claim paths via the same component:
+  1. `claim` (arcade-style, implementor-defined recipient binding).
+  2. `claim_with_eth_signature` (bearer credential, EIP-191 personal_sign).
+- `on_merkledrop_claim` callback for the implementing contract to mint / transfer / grant.
+
+### Architecture
+
+- **MerkledropComponent** (`merkledrop_component.cairo`): Starknet component with storage, register entrypoint, two claim entrypoints, hook trait, and view helpers.
+- **Signature helpers** (`signature.cairo`): EIP-191 personal_sign verification with the message format `"Claim on starknet with: 0x{recipient:x}"` (matches `viem.signMessage` output and `cartridge-gg/merkle_drop` upstream).
+- **Interfaces** (`interfaces.cairo`): Minimal `IERC721Read` so NFT-ownership bindings can call `owner_of` without dragging in `openzeppelin_token`.
+
+### Implementor contract (`MerkledropTrait`)
+
+| Method | Purpose |
+|---|---|
+| `get_recipient(data)` | Called by `claim` to decode `data` and return the address allowed to claim. NFT-gating: `ERC721.owner_of(token_id)` on the collection at `data[0]`. |
+| `on_merkledrop_claim(root, leaf, receiver, data)` | Distribute the asset/access. Same hook for both claim paths. |
+
+### Leaf data conventions
+
+`data` is `Span<felt252>` and the component treats it opaquely except for path-specific prefixes:
+
+- Bearer path: `[eth_address, ...payload]`
+- Arcade path (NFT-gating example): `[collection, token_id_low, token_id_high, ...payload]`
+
+A common convention is to keep payload at the end so the hook can extract it via `data[data.len() - 1]` without branching on the path.
+
+### Testing
+
+Unit tests live in `tests/test_merkledrop.cairo` and use snforge's `mock_call` to fake `owner_of` for the NFT path. The bearer path uses the same canonical test vector (`pk=0x420`, recipient `0x07db9cc...`, `v=28, r=0x8a..., s=0x20b6...`) as `cartridge-gg/merkle_drop`.
+
+Run: `snforge test merkledrop`.

--- a/packages/metagame/src/merkledrop/CLAUDE.md
+++ b/packages/metagame/src/merkledrop/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/metagame/src/merkledrop/README.md
+++ b/packages/metagame/src/merkledrop/README.md
@@ -1,0 +1,103 @@
+# Merkle Drop
+
+Single-use merkle-drop component for distributing on-chain access / assets, with two interchangeable claim paths sharing one nullifier and one callback.
+
+## Features
+
+- **On-chain tree building** (`alexandria_merkle_tree` Poseidon) — operator submits raw leaf data, contract computes the root, stores it, emits per-leaf proof events for off-chain pipelines to consume.
+- **Two claim paths**:
+  1. `claim` — arcade-style, gated by an implementor-defined `get_recipient(data)`. Used for NFT-ownership, allowlists, etc.
+  2. `claim_with_eth_signature` — bearer credential. Leaf's `data[0]` is an EVM address; the caller submits a secp256k1 personal_sign signature over `receiver`. Used for QR-code drops.
+- **Single-use nullifier** per `(root, leaf_hash)` regardless of claim path.
+- **Configurable expiry** per tree.
+- **Callback hook** `on_merkledrop_claim(root, leaf, receiver, data)` for the implementing contract to mint / transfer / grant.
+
+## Architecture
+
+| Module | Purpose |
+|---|---|
+| `merkledrop_component.cairo` | Starknet component with storage, register + two claim entrypoints, hook trait |
+| `signature.cairo` | EIP-191 personal_sign helpers for the bearer path |
+| `interfaces.cairo` | Minimal `IERC721Read` so the NFT-ownership pattern can call `owner_of` without pulling `openzeppelin_token` |
+
+## Interface
+
+### `MerkledropTrait` (implementor)
+
+| Method | Purpose |
+|---|---|
+| `get_recipient(data) -> ContractAddress` | Decode `data` and return who is allowed to call `claim`. Implementations decide the binding (NFT owner, hardcoded address, multisig, …). |
+| `on_merkledrop_claim(root, leaf, receiver, data)` | Distribute the asset / access after verification succeeds. Same hook for both claim paths. |
+
+### `InternalImpl` (component)
+
+| Method | Purpose |
+|---|---|
+| `register(data, end) -> felt252` | Build the tree from `data: Span<Span<felt252>>`, store root, emit events. Returns the root. |
+| `claim(root, proofs, data, receiver)` | Arcade-style claim path. Asserts `caller == get_recipient(data)`. |
+| `claim_with_eth_signature(root, proofs, data, receiver, sig)` | Bearer claim path. `data[0]` is the EVM address; `sig` must verify over `receiver`. |
+| `is_consumed(root, leaf_hash) -> bool` | Read the nullifier. |
+| `tree_expiry(root) -> u64` | Read a tree's expiry (0 if not registered). |
+
+## Leaf data conventions
+
+Leaf data is `Span<felt252>` — the contract treats it opaquely except for the first few slots needed by the claim path:
+
+- **Bearer path** (`claim_with_eth_signature`):
+  ```
+  [eth_address, ...payload]
+  ```
+  `data[0]` must be the EVM address. Remaining slots are the implementor's payload (e.g. asset id, amount).
+
+- **Arcade path** (`claim`):
+  Layout is fully determined by the implementor's `get_recipient`. Common shape for NFT-gating:
+  ```
+  [collection, token_id_low, token_id_high, ...payload]
+  ```
+  `get_recipient` reads these and returns `ERC721.owner_of(token_id)` on `collection`.
+
+A common convention is to put implementor-specific payload (e.g. `dungeon_id`) at the **end** of `data`, so both layouts can be read with `data[data.len() - 1]` without branching.
+
+## Off-chain pipeline
+
+The `register` call emits one `LeafRegistered` event per leaf containing the merkle proof. Off-chain code (e.g. a QR-generation tool) reads the tx receipt and assembles per-leaf claim URLs. See [cartridge-gg/qr-drops](https://github.com/Provable-Games/qr-drops) for a working pipeline.
+
+## Example
+
+```cairo
+use game_components_metagame::merkledrop::merkledrop_component::MerkledropComponent;
+use game_components_metagame::merkledrop::interfaces::{
+    IERC721ReadDispatcher, IERC721ReadDispatcherTrait,
+};
+
+#[starknet::contract]
+mod MyDungeon {
+    use super::*;
+
+    component!(path: MerkledropComponent, storage: merkledrop, event: MerkledropEvent);
+    impl MerkledropInternalImpl = MerkledropComponent::InternalImpl<ContractState>;
+
+    impl MerkledropImpl of MerkledropComponent::MerkledropTrait<ContractState> {
+        fn get_recipient(
+            self: @MerkledropComponent::ComponentState<ContractState>,
+            data: Span<felt252>,
+        ) -> starknet::ContractAddress {
+            let collection: starknet::ContractAddress = (*data.at(0)).try_into().unwrap();
+            let lo: u128 = (*data.at(1)).try_into().unwrap();
+            let hi: u128 = (*data.at(2)).try_into().unwrap();
+            IERC721ReadDispatcher { contract_address: collection }
+                .owner_of(u256 { low: lo, high: hi })
+        }
+
+        fn on_merkledrop_claim(
+            ref self: MerkledropComponent::ComponentState<ContractState>,
+            root: felt252,
+            leaf: felt252,
+            receiver: starknet::ContractAddress,
+            data: Span<felt252>,
+        ) {
+            // Mint / transfer / grant whatever to `receiver`.
+        }
+    }
+}
+```

--- a/packages/metagame/src/merkledrop/interfaces.cairo
+++ b/packages/metagame/src/merkledrop/interfaces.cairo
@@ -1,0 +1,9 @@
+use starknet::ContractAddress;
+
+/// Minimal subset of ERC721 used by the merkle drop component. Lets the
+/// component verify NFT ownership without pulling in the full
+/// `openzeppelin_token` dependency for one method.
+#[starknet::interface]
+pub trait IERC721Read<T> {
+    fn owner_of(self: @T, token_id: u256) -> ContractAddress;
+}

--- a/packages/metagame/src/merkledrop/merkledrop_component.cairo
+++ b/packages/metagame/src/merkledrop/merkledrop_component.cairo
@@ -1,11 +1,17 @@
 //! Merkle-drop component with two claim paths sharing one nullifier + hook.
 //!
 //! Shared mechanics:
-//!   - On-chain tree building (alexandria Poseidon). The operator submits
-//!     raw leaf data; the contract computes the root, stores it, and emits
-//!     one `LeafRegistered` event per leaf carrying the proof. Off-chain
-//!     pipelines parse these events from the registration receipt to
-//!     assemble per-leaf claim URLs / proofs.
+//!   - Two registration paths:
+//!       * `register(data, end)` -- on-chain tree building (alexandria
+//!         Poseidon). The operator submits raw leaf data; the contract
+//!         computes the root, stores it, and emits one `LeafRegistered`
+//!         event per leaf carrying the proof. Suitable for small campaigns
+//!         (under ~1000 leaves; Starknet caps events per tx at 1000).
+//!       * `register_root(root, end)` -- off-chain tree building. The
+//!         operator computes the root off-chain (using the same Poseidon
+//!         scheme this component uses for verification) and only the root
+//!         is stored on-chain. Required for large campaigns (10k+ leaves)
+//!         where per-leaf events would blow the event limit.
 //!   - Per-leaf single-use nullifier keyed by `(root, leaf_hash)`.
 //!   - The implementing contract receives an `on_merkledrop_claim`
 //!     callback after verification succeeds.
@@ -110,6 +116,27 @@ pub mod MerkledropComponent {
         +Drop<TContractState>,
         impl Merkledrop: MerkledropTrait<TContractState>,
     > of InternalTrait<TContractState> {
+        /// Register a precomputed root without building the tree on-chain.
+        /// The implementor is responsible for computing the root off-chain
+        /// (using the same Poseidon scheme this component uses for verification).
+        /// Emits a single `MerkleTreeCreated` event with `leaf_count = 0` (the
+        /// component doesn't know -- that's an off-chain detail).
+        ///
+        /// Use this path for large campaigns (10k+ leaves) where emitting one
+        /// `LeafRegistered` event per leaf would exceed Starknet's 1000-events
+        /// -per-tx limit. The off-chain pipeline already has the proofs, so
+        /// it can distribute them directly without parsing them out of a
+        /// registration receipt.
+        fn register_root(
+            ref self: ComponentState<TContractState>, root: felt252, end: u64,
+        ) -> felt252 {
+            assert!(root != 0, "merkledrop: zero root");
+            assert!(self.trees.entry(root).read() == 0, "merkledrop: tree exists");
+            self.trees.entry(root).write(end);
+            self.emit(MerkleTreeCreated { root, end, leaf_count: 0 });
+            root
+        }
+
         /// Build a tree from raw leaf data, store the root, and emit per-leaf
         /// proofs as events. Returns the root, which doubles as the tree id.
         fn register(

--- a/packages/metagame/src/merkledrop/merkledrop_component.cairo
+++ b/packages/metagame/src/merkledrop/merkledrop_component.cairo
@@ -1,0 +1,231 @@
+//! Merkle-drop component with two claim paths sharing one nullifier + hook.
+//!
+//! Shared mechanics:
+//!   - On-chain tree building (alexandria Poseidon). The operator submits
+//!     raw leaf data; the contract computes the root, stores it, and emits
+//!     one `LeafRegistered` event per leaf carrying the proof. Off-chain
+//!     pipelines parse these events from the registration receipt to
+//!     assemble per-leaf claim URLs / proofs.
+//!   - Per-leaf single-use nullifier keyed by `(root, leaf_hash)`.
+//!   - The implementing contract receives an `on_merkledrop_claim`
+//!     callback after verification succeeds.
+//!
+//! Claim paths:
+//!
+//!   A. `claim(root, proofs, data, receiver)` (arcade-style).
+//!      The implementing contract overrides `get_recipient` to extract the
+//!      expected claimer from `data`. The component asserts
+//!      `get_caller_address() == get_recipient(data)`. This gates
+//!      NFT-ownership flows, allowlists, etc.
+//!
+//!   B. `claim_with_eth_signature(root, proofs, data, receiver, signature)`
+//!      (bearer credential). Leaf's `data[0]` is an EVM address; the caller
+//!      submits a secp256k1 signature over `receiver` that recovers to
+//!      that address. Used for QR-code drops where the bearer key is the
+//!      credential.
+
+#[starknet::component]
+pub mod MerkledropComponent {
+    use alexandria_merkle_tree::merkle_tree::poseidon::PoseidonHasherImpl;
+    use alexandria_merkle_tree::merkle_tree::{
+        Hasher, MerkleTree, MerkleTreeImpl, StoredMerkleTreeImpl,
+    };
+    use core::poseidon::poseidon_hash_span;
+    use starknet::eth_address::EthAddress;
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
+    use crate::merkledrop::signature::{EthereumSignature, verify_claim_signature};
+
+    /// Implementing contracts override both methods.
+    pub trait MerkledropTrait<TContractState, +HasComponent<TContractState>> {
+        /// Extract the expected claimer from a leaf's `data`. Called only by
+        /// `claim` (the arcade-style path). Implementations decide the
+        /// binding -- e.g. read `data[0]` as a Starknet address, or call
+        /// `ERC721.owner_of` on `(data[0], u256 { low: data[1], high: data[2] })`
+        /// for NFT-gating.
+        fn get_recipient(
+            self: @ComponentState<TContractState>, data: Span<felt252>,
+        ) -> ContractAddress;
+
+        /// Distribute the asset/access after verification succeeds.
+        fn on_merkledrop_claim(
+            ref self: ComponentState<TContractState>,
+            root: felt252,
+            leaf: felt252,
+            receiver: ContractAddress,
+            data: Span<felt252>,
+        );
+    }
+
+    #[storage]
+    pub struct Storage {
+        /// root -> expiry timestamp (0 means tree not registered).
+        pub trees: Map<felt252, u64>,
+        /// (root, leaf_hash) -> already consumed (nullifier).
+        pub claims: Map<(felt252, felt252), bool>,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        MerkleTreeCreated: MerkleTreeCreated,
+        LeafRegistered: LeafRegistered,
+        ClaimSucceeded: ClaimSucceeded,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct MerkleTreeCreated {
+        #[key]
+        pub root: felt252,
+        pub end: u64,
+        pub leaf_count: u32,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct LeafRegistered {
+        #[key]
+        pub root: felt252,
+        #[key]
+        pub index: u32,
+        pub leaf_hash: felt252,
+        pub proofs: Span<felt252>,
+        pub data: Span<felt252>,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct ClaimSucceeded {
+        #[key]
+        pub root: felt252,
+        #[key]
+        pub leaf_hash: felt252,
+        pub receiver: ContractAddress,
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        +Drop<TContractState>,
+        impl Merkledrop: MerkledropTrait<TContractState>,
+    > of InternalTrait<TContractState> {
+        /// Build a tree from raw leaf data, store the root, and emit per-leaf
+        /// proofs as events. Returns the root, which doubles as the tree id.
+        fn register(
+            ref self: ComponentState<TContractState>, data: Span<Span<felt252>>, end: u64,
+        ) -> felt252 {
+            assert!(data.len() > 0, "merkledrop: empty data");
+
+            let mut leaves: Array<felt252> = array![];
+            let mut i: u32 = 0;
+            while i < data.len() {
+                leaves.append(poseidon_hash_span(*data.at(i)));
+                i += 1;
+            }
+
+            let mut tree = StoredMerkleTreeImpl::<_, PoseidonHasherImpl>::new(leaves.clone());
+            let root = StoredMerkleTreeImpl::<_, PoseidonHasherImpl>::get_root(ref tree);
+
+            assert!(self.trees.entry(root).read() == 0, "merkledrop: tree exists");
+            self.trees.entry(root).write(end);
+
+            self.emit(MerkleTreeCreated { root, end, leaf_count: data.len() });
+
+            let mut index: u32 = 0;
+            while index < data.len() {
+                let proofs = StoredMerkleTreeImpl::<
+                    _, PoseidonHasherImpl,
+                >::get_proof(ref tree, index);
+                self
+                    .emit(
+                        LeafRegistered {
+                            root,
+                            index,
+                            leaf_hash: *leaves.at(index),
+                            proofs,
+                            data: *data.at(index),
+                        },
+                    );
+                index += 1;
+            }
+
+            root
+        }
+
+        /// Arcade-style claim. The implementing contract's `get_recipient`
+        /// decides who is allowed to claim this leaf; the component just
+        /// asserts the caller matches.
+        fn claim(
+            ref self: ComponentState<TContractState>,
+            root: felt252,
+            proofs: Span<felt252>,
+            data: Span<felt252>,
+            receiver: ContractAddress,
+        ) {
+            let end = self.trees.entry(root).read();
+            assert!(end != 0, "merkledrop: tree not found");
+            assert!(get_block_timestamp() < end, "merkledrop: tree expired");
+            assert!(data.len() > 0, "merkledrop: empty leaf data");
+
+            let expected = Merkledrop::get_recipient(@self, data);
+            assert!(expected == get_caller_address(), "merkledrop: not recipient");
+
+            self.verify_consume_and_forward(root, proofs, data, receiver);
+        }
+
+        /// Bearer-credential claim. The leaf's `data[0]` must equal the EVM
+        /// address recovered from `signature` over `receiver`.
+        fn claim_with_eth_signature(
+            ref self: ComponentState<TContractState>,
+            root: felt252,
+            proofs: Span<felt252>,
+            data: Span<felt252>,
+            receiver: ContractAddress,
+            signature: EthereumSignature,
+        ) {
+            let end = self.trees.entry(root).read();
+            assert!(end != 0, "merkledrop: tree not found");
+            assert!(get_block_timestamp() < end, "merkledrop: tree expired");
+            assert!(data.len() > 0, "merkledrop: empty leaf data");
+
+            let eth_address: EthAddress = (*data.at(0)).try_into().unwrap();
+            verify_claim_signature(signature, eth_address, receiver);
+
+            self.verify_consume_and_forward(root, proofs, data, receiver);
+        }
+
+        fn is_consumed(
+            self: @ComponentState<TContractState>, root: felt252, leaf_hash: felt252,
+        ) -> bool {
+            self.claims.entry((root, leaf_hash)).read()
+        }
+
+        fn tree_expiry(self: @ComponentState<TContractState>, root: felt252) -> u64 {
+            self.trees.entry(root).read()
+        }
+
+        /// Shared tail used by both claim paths after credential verification:
+        /// merkle proof check, nullifier consume, event, hook callback.
+        fn verify_consume_and_forward(
+            ref self: ComponentState<TContractState>,
+            root: felt252,
+            proofs: Span<felt252>,
+            data: Span<felt252>,
+            receiver: ContractAddress,
+        ) {
+            let leaf = poseidon_hash_span(data);
+            let mut mt: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasherImpl>::new();
+            let valid = MerkleTreeImpl::<_, PoseidonHasherImpl>::verify(ref mt, root, leaf, proofs);
+            assert!(valid, "merkledrop: invalid proof");
+
+            let already = self.claims.entry((root, leaf)).read();
+            assert!(!already, "merkledrop: already claimed");
+            self.claims.entry((root, leaf)).write(true);
+
+            self.emit(ClaimSucceeded { root, leaf_hash: leaf, receiver });
+
+            Merkledrop::on_merkledrop_claim(ref self, root, leaf, receiver, data);
+        }
+    }
+}

--- a/packages/metagame/src/merkledrop/signature.cairo
+++ b/packages/metagame/src/merkledrop/signature.cairo
@@ -1,0 +1,62 @@
+//! EIP-191 personal_sign verification for Starknet recipients.
+//!
+//! Ported from `cartridge-gg/merkle_drop/src/forwarder/signature.cairo` so a
+//! claimer holding a secp256k1 private key can sign the destination
+//! Starknet recipient and the contract can recover the EVM address that
+//! signed.
+
+use starknet::ContractAddress;
+use starknet::eth_address::EthAddress;
+use starknet::eth_signature::verify_eth_signature;
+use starknet::secp256_trait::signature_from_vrs;
+
+#[derive(Drop, Copy, Serde)]
+pub struct EthereumSignature {
+    pub v: u32,
+    pub r: u256,
+    pub s: u256,
+}
+
+/// Verifies that `sig` is a secp256k1 signature, made by `eth_address`,
+/// over the message embedding `recipient`. Panics on failure.
+pub fn verify_claim_signature(
+    sig: EthereumSignature, eth_address: EthAddress, recipient: ContractAddress,
+) {
+    let message = build_message(recipient);
+    let msg_hash = hash_message(@message);
+    let signature = signature_from_vrs(sig.v, sig.r, sig.s);
+    verify_eth_signature(msg_hash, signature, eth_address);
+}
+
+/// Builds the canonical claim message:
+///
+///   `"Claim on starknet with: 0x{recipient:x}"`
+///
+/// Lowercase hex with no leading zeros so the format matches viem's
+/// `signMessage({ message: "..." })` output.
+pub fn build_message(address: ContractAddress) -> ByteArray {
+    let header: ByteArray = "Ethereum Signed Message:\n";
+    let addr_felt: felt252 = address.into();
+    let message: ByteArray = format!("Claim on starknet with: 0x{:x}", addr_felt);
+    let message_len = format!("{}", message.len());
+    format!("{}{}{}", header, message_len, message)
+}
+
+/// Computes the EIP-191 personal_sign hash:
+///
+///   `keccak256("\x19" + "Ethereum Signed Message:\n" + len(msg) + msg)`
+pub fn hash_message(message: @ByteArray) -> u256 {
+    let mut bytes: ByteArray = Default::default();
+    let mut i = 0;
+    bytes.append_byte(0x19); // EIP-191 prefix byte
+    while i < message.len() {
+        let char = message.at(i).unwrap();
+        bytes.append_byte(char);
+        i += 1;
+    }
+    let keccak_le = core::keccak::compute_keccak_byte_array(@bytes);
+    u256 {
+        high: core::integer::u128_byte_reverse(keccak_le.low),
+        low: core::integer::u128_byte_reverse(keccak_le.high),
+    }
+}

--- a/packages/metagame/src/merkledrop/tests.cairo
+++ b/packages/metagame/src/merkledrop/tests.cairo
@@ -1,0 +1,2 @@
+pub mod mocks;
+mod test_merkledrop;

--- a/packages/metagame/src/merkledrop/tests/mocks.cairo
+++ b/packages/metagame/src/merkledrop/tests/mocks.cairo
@@ -1,0 +1,1 @@
+pub mod mock_dungeon;

--- a/packages/metagame/src/merkledrop/tests/mocks/mock_dungeon.cairo
+++ b/packages/metagame/src/merkledrop/tests/mocks/mock_dungeon.cairo
@@ -1,0 +1,128 @@
+//! Mock dungeon contract for merkledrop integration tests.
+//!
+//! Implements both `MerkledropTrait` methods:
+//!   - `get_recipient`: returns `owner_of` on the NFT (collection, token_id)
+//!     committed in `data[0..3]`.
+//!   - `on_merkledrop_claim`: stores a boolean access flag keyed by
+//!     `(receiver, dungeon_id)` where `dungeon_id` is the last data element.
+
+use starknet::ContractAddress;
+use crate::merkledrop::signature::EthereumSignature;
+
+#[starknet::interface]
+pub trait IMockDungeon<T> {
+    fn register_drop(ref self: T, data: Span<Span<felt252>>, end: u64) -> felt252;
+    fn claim(
+        ref self: T,
+        root: felt252,
+        proofs: Span<felt252>,
+        data: Span<felt252>,
+        receiver: ContractAddress,
+    );
+    fn claim_with_eth_signature(
+        ref self: T,
+        root: felt252,
+        proofs: Span<felt252>,
+        data: Span<felt252>,
+        receiver: ContractAddress,
+        signature: EthereumSignature,
+    );
+    fn has_access(self: @T, account: ContractAddress, dungeon_id: u32) -> bool;
+    fn is_consumed(self: @T, root: felt252, leaf_hash: felt252) -> bool;
+    fn tree_expiry(self: @T, root: felt252) -> u64;
+}
+
+#[starknet::contract]
+pub mod MockDungeon {
+    use starknet::ContractAddress;
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use crate::merkledrop::interfaces::{IERC721ReadDispatcher, IERC721ReadDispatcherTrait};
+    use crate::merkledrop::merkledrop_component::MerkledropComponent;
+    use crate::merkledrop::merkledrop_component::MerkledropComponent::InternalTrait;
+    use crate::merkledrop::signature::EthereumSignature;
+
+    component!(path: MerkledropComponent, storage: merkledrop, event: MerkledropEvent);
+
+    impl MerkledropInternalImpl = MerkledropComponent::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        access: Map<(ContractAddress, u32), bool>,
+        #[substorage(v0)]
+        merkledrop: MerkledropComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        MerkledropEvent: MerkledropComponent::Event,
+    }
+
+    #[abi(embed_v0)]
+    impl MockDungeonImpl of super::IMockDungeon<ContractState> {
+        fn register_drop(ref self: ContractState, data: Span<Span<felt252>>, end: u64) -> felt252 {
+            self.merkledrop.register(data, end)
+        }
+
+        fn claim(
+            ref self: ContractState,
+            root: felt252,
+            proofs: Span<felt252>,
+            data: Span<felt252>,
+            receiver: ContractAddress,
+        ) {
+            self.merkledrop.claim(root, proofs, data, receiver);
+        }
+
+        fn claim_with_eth_signature(
+            ref self: ContractState,
+            root: felt252,
+            proofs: Span<felt252>,
+            data: Span<felt252>,
+            receiver: ContractAddress,
+            signature: EthereumSignature,
+        ) {
+            self.merkledrop.claim_with_eth_signature(root, proofs, data, receiver, signature);
+        }
+
+        fn has_access(self: @ContractState, account: ContractAddress, dungeon_id: u32) -> bool {
+            self.access.entry((account, dungeon_id)).read()
+        }
+        fn is_consumed(self: @ContractState, root: felt252, leaf_hash: felt252) -> bool {
+            self.merkledrop.is_consumed(root, leaf_hash)
+        }
+        fn tree_expiry(self: @ContractState, root: felt252) -> u64 {
+            self.merkledrop.tree_expiry(root)
+        }
+    }
+
+    impl MerkledropImpl of MerkledropComponent::MerkledropTrait<ContractState> {
+        fn get_recipient(
+            self: @MerkledropComponent::ComponentState<ContractState>, data: Span<felt252>,
+        ) -> ContractAddress {
+            assert!(data.len() >= 3, "MockDungeon: leaf missing nft binding");
+            let collection: ContractAddress = (*data.at(0)).try_into().unwrap();
+            let lo: u128 = (*data.at(1)).try_into().unwrap();
+            let hi: u128 = (*data.at(2)).try_into().unwrap();
+            let token_id = u256 { low: lo, high: hi };
+            IERC721ReadDispatcher { contract_address: collection }.owner_of(token_id)
+        }
+
+        fn on_merkledrop_claim(
+            ref self: MerkledropComponent::ComponentState<ContractState>,
+            root: felt252,
+            leaf: felt252,
+            receiver: ContractAddress,
+            data: Span<felt252>,
+        ) {
+            let _ = (root, leaf);
+            assert!(data.len() >= 2, "MockDungeon: leaf missing dungeon_id");
+            let dungeon_id: u32 = (*data.at(data.len() - 1)).try_into().unwrap();
+            let mut contract = self.get_contract_mut();
+            contract.access.entry((receiver, dungeon_id)).write(true);
+        }
+    }
+}

--- a/packages/metagame/src/merkledrop/tests/mocks/mock_dungeon.cairo
+++ b/packages/metagame/src/merkledrop/tests/mocks/mock_dungeon.cairo
@@ -12,6 +12,7 @@ use crate::merkledrop::signature::EthereumSignature;
 #[starknet::interface]
 pub trait IMockDungeon<T> {
     fn register_drop(ref self: T, data: Span<Span<felt252>>, end: u64) -> felt252;
+    fn register_drop_root(ref self: T, root: felt252, end: u64) -> felt252;
     fn claim(
         ref self: T,
         root: felt252,
@@ -65,6 +66,10 @@ pub mod MockDungeon {
     impl MockDungeonImpl of super::IMockDungeon<ContractState> {
         fn register_drop(ref self: ContractState, data: Span<Span<felt252>>, end: u64) -> felt252 {
             self.merkledrop.register(data, end)
+        }
+
+        fn register_drop_root(ref self: ContractState, root: felt252, end: u64) -> felt252 {
+            self.merkledrop.register_root(root, end)
         }
 
         fn claim(

--- a/packages/metagame/src/merkledrop/tests/test_merkledrop.cairo
+++ b/packages/metagame/src/merkledrop/tests/test_merkledrop.cairo
@@ -1,8 +1,12 @@
+use alexandria_merkle_tree::merkle_tree::poseidon::PoseidonHasherImpl;
+use alexandria_merkle_tree::merkle_tree::{Hasher, MerkleTree, MerkleTreeImpl};
+use core::poseidon::poseidon_hash_span;
 use snforge_std::{
-    ContractClassTrait, DeclareResultTrait, declare, mock_call, start_cheat_caller_address,
-    stop_cheat_caller_address,
+    ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, declare, mock_call, spy_events,
+    start_cheat_caller_address, stop_cheat_caller_address,
 };
 use starknet::ContractAddress;
+use crate::merkledrop::merkledrop_component::MerkledropComponent;
 use crate::merkledrop::signature::EthereumSignature;
 use crate::merkledrop::tests::mocks::mock_dungeon::{
     IMockDungeonDispatcher, IMockDungeonDispatcherTrait,
@@ -167,4 +171,80 @@ fn test__claim_unknown_tree_fails() {
     let leaf = eth_leaf_data();
     let proof: Array<felt252> = array![0];
     dungeon.claim_with_eth_signature(0x123, proof.span(), leaf.span(), recipient, test_signature());
+}
+
+// ------------------------ Off-chain root registration -------------------------
+
+#[test]
+fn test__register_root_stores_tree() {
+    let dungeon = deploy_dungeon();
+    let mut spy = spy_events();
+
+    let root: felt252 = 0xabc;
+    let end: u64 = 0xffffffffffffffff;
+    let returned = dungeon.register_drop_root(root, end);
+
+    assert!(returned == root, "register_root must return the input root");
+    assert!(dungeon.tree_expiry(root) == end, "tree expiry not stored");
+
+    // A single MerkleTreeCreated event with leaf_count = 0 (off-chain detail).
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    dungeon.contract_address,
+                    MerkledropComponent::Event::MerkleTreeCreated(
+                        MerkledropComponent::MerkleTreeCreated { root, end, leaf_count: 0 },
+                    ),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: "merkledrop: zero root")]
+fn test__register_root_rejects_zero() {
+    let dungeon = deploy_dungeon();
+    dungeon.register_drop_root(0, 0xffffffffffffffff);
+}
+
+#[test]
+#[should_panic(expected: "merkledrop: tree exists")]
+fn test__register_root_rejects_duplicate() {
+    let dungeon = deploy_dungeon();
+    let root: felt252 = 0xabc;
+    let end: u64 = 0xffffffffffffffff;
+    dungeon.register_drop_root(root, end);
+    // Second registration of the same root must revert.
+    dungeon.register_drop_root(root, end);
+}
+
+#[test]
+fn test__claim_with_eth_signature_after_register_root_succeeds() {
+    let dungeon = deploy_dungeon();
+    let recipient: ContractAddress = RECIPIENT_FELT.try_into().unwrap();
+
+    // Compute the root off-chain (here: in the test) using the same Poseidon
+    // scheme the component uses for verification. For a 1-leaf tree, the
+    // alexandria pad makes the sibling proof `[0]`, so the root is just
+    // poseidon-hash of (leaf, 0) in sorted order.
+    let leaf = eth_leaf_data();
+    let leaf_hash = poseidon_hash_span(leaf.span());
+    let proof: Array<felt252> = array![0];
+    let mut mt: MerkleTree<Hasher> = MerkleTreeImpl::<_, PoseidonHasherImpl>::new();
+    let root = MerkleTreeImpl::<
+        _, PoseidonHasherImpl,
+    >::compute_root(ref mt, leaf_hash, proof.span());
+
+    // Register only the precomputed root. No per-leaf events emitted.
+    let end: u64 = 0xffffffffffffffff;
+    let returned = dungeon.register_drop_root(root, end);
+    assert!(returned == root, "register_root must return the input root");
+    assert!(dungeon.tree_expiry(root) == end, "tree expiry not stored");
+
+    // Claim against the off-chain-built root using the known-good signature.
+    dungeon.claim_with_eth_signature(root, proof.span(), leaf.span(), recipient, test_signature());
+
+    assert!(dungeon.has_access(recipient, DUNGEON_ID), "access not granted");
+    assert!(dungeon.is_consumed(root, leaf_hash), "nullifier not set");
 }

--- a/packages/metagame/src/merkledrop/tests/test_merkledrop.cairo
+++ b/packages/metagame/src/merkledrop/tests/test_merkledrop.cairo
@@ -1,0 +1,170 @@
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, mock_call, start_cheat_caller_address,
+    stop_cheat_caller_address,
+};
+use starknet::ContractAddress;
+use crate::merkledrop::signature::EthereumSignature;
+use crate::merkledrop::tests::mocks::mock_dungeon::{
+    IMockDungeonDispatcher, IMockDungeonDispatcherTrait,
+};
+
+// Test vectors from cartridge-gg/merkle_drop -- pk=0x420 → this eth address.
+const ETH_ADDRESS: felt252 = 0x4884ABe82470adf54f4e19Fa39712384c05112be;
+
+// Recipient used in the upstream signature test vector.
+const RECIPIENT_FELT: felt252 = 0x7db9cc4a5e5485becbde0c40e71af59d72c543dea4cdeddf3c54ba03fdf14eb;
+
+const NFT_HOLDER_FELT: felt252 = 0x2222;
+const NFT_COLLECTION_FELT: felt252 = 0xc011ec7;
+const NFT_TOKEN_ID_LO: felt252 = 42;
+const NFT_TOKEN_ID_HI: felt252 = 0;
+const DUNGEON_ID: u32 = 1;
+
+fn deploy_dungeon() -> IMockDungeonDispatcher {
+    let contract = declare("MockDungeon").unwrap().contract_class();
+    let (address, _) = contract.deploy(@array![]).unwrap();
+    IMockDungeonDispatcher { contract_address: address }
+}
+
+fn test_signature() -> EthereumSignature {
+    EthereumSignature {
+        v: 28,
+        r: 0x8a616cce850f16086b7f189ca3075e730cc8e3c891adb3ce6ff32e2ae5441fa4,
+        s: 0x20b6bd7126554394b4d9ebc9b57f95aa21f0d84a1211499d5bc6ec4faad266e3,
+    }
+}
+
+fn eth_leaf_data() -> Array<felt252> {
+    array![ETH_ADDRESS, DUNGEON_ID.into()]
+}
+
+fn nft_leaf_data() -> Array<felt252> {
+    array![NFT_COLLECTION_FELT, NFT_TOKEN_ID_LO, NFT_TOKEN_ID_HI, DUNGEON_ID.into()]
+}
+
+// ------------------------ ETH-signature path -------------------------
+
+#[test]
+fn test__eth_sig_register_and_claim_succeeds() {
+    let dungeon = deploy_dungeon();
+    let recipient: ContractAddress = RECIPIENT_FELT.try_into().unwrap();
+
+    let leaf = eth_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+    assert!(dungeon.tree_expiry(root) == 0xffffffffffffffff, "tree not registered");
+
+    // For a tree of size 1, alexandria pads to [leaf, 0]; sibling proof is [0].
+    let proof: Array<felt252> = array![0];
+    dungeon.claim_with_eth_signature(root, proof.span(), leaf.span(), recipient, test_signature());
+
+    assert!(dungeon.has_access(recipient, DUNGEON_ID), "access not granted");
+}
+
+#[test]
+#[should_panic(expected: "merkledrop: already claimed")]
+fn test__eth_sig_double_claim_fails() {
+    let dungeon = deploy_dungeon();
+    let recipient: ContractAddress = RECIPIENT_FELT.try_into().unwrap();
+
+    let leaf = eth_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+    let proof: Array<felt252> = array![0];
+    dungeon.claim_with_eth_signature(root, proof.span(), leaf.span(), recipient, test_signature());
+
+    // Second claim against the same leaf must revert.
+    dungeon.claim_with_eth_signature(root, proof.span(), leaf.span(), recipient, test_signature());
+}
+
+#[test]
+#[should_panic(expected: 'Invalid signature')]
+fn test__eth_sig_wrong_recipient_fails() {
+    let dungeon = deploy_dungeon();
+    let leaf = eth_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+
+    // The signature was made for the canonical recipient. Submitting it
+    // with a different recipient should fail signature verification.
+    let other_recipient: ContractAddress = 0xdead.try_into().unwrap();
+    let proof: Array<felt252> = array![0];
+    dungeon
+        .claim_with_eth_signature(
+            root, proof.span(), leaf.span(), other_recipient, test_signature(),
+        );
+}
+
+// ------------------------ Arcade / NFT-ownership path -------------------------
+
+#[test]
+fn test__nft_register_and_claim_succeeds() {
+    let dungeon = deploy_dungeon();
+    let nft_holder: ContractAddress = NFT_HOLDER_FELT.try_into().unwrap();
+    let collection: ContractAddress = NFT_COLLECTION_FELT.try_into().unwrap();
+
+    let leaf = nft_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+
+    // Mock the ERC721 `owner_of` so it reports `nft_holder` owns the token.
+    mock_call(collection, selector!("owner_of"), nft_holder, 1);
+
+    start_cheat_caller_address(dungeon.contract_address, nft_holder);
+    let proof: Array<felt252> = array![0];
+    dungeon.claim(root, proof.span(), leaf.span(), nft_holder);
+    stop_cheat_caller_address(dungeon.contract_address);
+
+    assert!(dungeon.has_access(nft_holder, DUNGEON_ID), "access not granted");
+}
+
+#[test]
+#[should_panic(expected: "merkledrop: not recipient")]
+fn test__nft_non_owner_cannot_claim() {
+    let dungeon = deploy_dungeon();
+    let nft_holder: ContractAddress = NFT_HOLDER_FELT.try_into().unwrap();
+    let imposter: ContractAddress = 0xbeef.try_into().unwrap();
+    let collection: ContractAddress = NFT_COLLECTION_FELT.try_into().unwrap();
+
+    let leaf = nft_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+
+    // owner_of returns nft_holder, but the imposter is calling.
+    mock_call(collection, selector!("owner_of"), nft_holder, 1);
+
+    start_cheat_caller_address(dungeon.contract_address, imposter);
+    let proof: Array<felt252> = array![0];
+    dungeon.claim(root, proof.span(), leaf.span(), imposter);
+}
+
+#[test]
+#[should_panic(expected: "merkledrop: already claimed")]
+fn test__nft_double_claim_fails() {
+    let dungeon = deploy_dungeon();
+    let nft_holder: ContractAddress = NFT_HOLDER_FELT.try_into().unwrap();
+    let collection: ContractAddress = NFT_COLLECTION_FELT.try_into().unwrap();
+
+    let leaf = nft_leaf_data();
+    let all_data = array![leaf.span()];
+    let root = dungeon.register_drop(all_data.span(), 0xffffffffffffffff);
+
+    mock_call(collection, selector!("owner_of"), nft_holder, 2);
+
+    start_cheat_caller_address(dungeon.contract_address, nft_holder);
+    let proof: Array<felt252> = array![0];
+    dungeon.claim(root, proof.span(), leaf.span(), nft_holder);
+    dungeon.claim(root, proof.span(), leaf.span(), nft_holder);
+}
+
+// ------------------------ Shared mechanics -------------------------
+
+#[test]
+#[should_panic(expected: "merkledrop: tree not found")]
+fn test__claim_unknown_tree_fails() {
+    let dungeon = deploy_dungeon();
+    let recipient: ContractAddress = RECIPIENT_FELT.try_into().unwrap();
+    let leaf = eth_leaf_data();
+    let proof: Array<felt252> = array![0];
+    dungeon.claim_with_eth_signature(0x123, proof.span(), leaf.span(), recipient, test_signature());
+}


### PR DESCRIPTION
Adds a reusable Starknet component to `packages/metagame` for single-use merkle-drop claims, with two interchangeable credential paths sharing one nullifier and one callback. Based on `cartridge-gg/arcade`'s merkledrop pattern, de-dojo'd, with a second claim path for bearer credentials.

## Summary

- **`claim(root, proofs, data, receiver)`** — arcade-style. The implementing contract overrides `get_recipient(data)` to decide who is allowed to claim. Used for NFT-ownership gates (caller must currently own a specific NFT), allowlists, custom validators.
- **`claim_with_eth_signature(root, proofs, data, receiver, sig)`** — bearer credential. The leaf's `data[0]` is an EVM address; the caller submits a secp256k1 personal_sign signature over `receiver`. Used for QR-code drops where the bearer key is the credential.

Both paths share:
- On-chain tree construction (alexandria Poseidon) via `register()`. Operator submits raw leaf data; component computes root, stores it, emits one `LeafRegistered` event per leaf carrying the proof. Off-chain pipelines parse these events to assemble per-leaf claim URLs.
- Single-use nullifier per `(root, leaf_hash)`.
- `on_merkledrop_claim(root, leaf, receiver, data)` hook for the implementing contract to mint / transfer / grant.
- Configurable per-tree expiry.

## Architecture

| File | Purpose |
|---|---|
| `merkledrop_component.cairo` | Starknet component (storage, register + 2 claim entrypoints, hook trait, view helpers) |
| `signature.cairo` | EIP-191 personal_sign verification — matches `viem.signMessage` output and `cartridge-gg/merkle_drop`'s canonical message format |
| `interfaces.cairo` | Minimal `IERC721Read` so NFT-ownership bindings can call `owner_of` without pulling `openzeppelin_token` |

## Test plan

7 snforge tests covering both paths and shared mechanics:
- [x] eth-sig: register + claim succeeds (canonical `pk=0x420` test vector from `cartridge-gg/merkle_drop`)
- [x] eth-sig: double-claim reverts on nullifier
- [x] eth-sig: signature bound to receiver (wrong receiver reverts)
- [x] NFT path: register + claim succeeds (`mock_call` on `owner_of`)
- [x] NFT path: non-owner cannot claim
- [x] NFT path: double-claim reverts on nullifier
- [x] unknown tree reverts

Run: `cd packages/metagame && snforge test merkledrop`.

## CI

- Added `merkledrop` row to `main-ci.yml` and `pr-ci.yml` matrix.
- `codecov.yml` `after_n_builds`: 16 → 17.

## Dependencies

Adds `alexandria_merkle_tree v0.9.0` to workspace deps (used by the Poseidon `StoredMerkleTreeImpl`).

## Consumer

A working off-chain QR-drop pipeline that registers + serves claims against this component lives at https://github.com/Provable-Games/qr-drops — see its `contracts/src/dungeon.cairo` and `contracts/src/dungeon_denshokan.cairo` for example consumer contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a merkledrop module enabling single-use on-chain Merkle-drop claims with two claim paths (bearer and NFT-gated), expiry, per-leaf nullifiers, and signature-based claims.

* **Documentation**
  * Added comprehensive merkledrop docs and README describing usage, data formats, and integration hooks.

* **Tests**
  * Added extensive test suite and mocks covering registration, both claim flows, signature verification, double-claim prevention, and error cases.

* **Chores**
  * Updated CI matrices/workflows, added a workspace dependency, and bumped coverage baseline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Provable-Games/game-components/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->