### PR TITLE
perf(token)!: rework mint_batch_recipients with per-recipient counts

### DIFF
--- a/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
@@ -480,7 +480,8 @@ mod MockMinigameTokenFuzz {
         IMINIGAME_TOKEN_ID, IMinigameToken,
     };
     use game_components_embeddable_game_standard::token::structs::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use openzeppelin_interfaces::introspection::ISRC5;
     use starknet::ContractAddress;
@@ -775,46 +776,6 @@ mod MockMinigameTokenFuzz {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            let mut results = array![];
-            let mut i = 0;
-            loop {
-                if i >= mints.len() {
-                    break;
-                }
-                let params = mints.at(i);
-                let context_clone = match params.context {
-                    Option::Some(ctx) => Option::Some(ctx.clone()),
-                    Option::None => Option::None,
-                };
-                let client_url_clone = match params.client_url {
-                    Option::Some(url) => Option::Some(url.clone()),
-                    Option::None => Option::None,
-                };
-                let token_id = self
-                    .mint(
-                        *params.game_address,
-                        *params.player_name,
-                        *params.settings_id,
-                        *params.start,
-                        *params.end,
-                        *params.objective_id,
-                        context_clone,
-                        client_url_clone,
-                        *params.renderer_address,
-                        Option::None,
-                        *params.to,
-                        *params.soulbound,
-                        *params.paymaster,
-                        *params.salt,
-                        *params.metadata,
-                    );
-                results.append(token_id);
-                i += 1;
-            }
-            results
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -827,7 +788,7 @@ mod MockMinigameTokenFuzz {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,

--- a/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
@@ -781,7 +781,8 @@ mod MockMinigameTokenForLibs {
         IMINIGAME_TOKEN_ID, IMinigameToken,
     };
     use game_components_embeddable_game_standard::token::structs::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use openzeppelin_interfaces::introspection::ISRC5;
     use starknet::ContractAddress;
@@ -1068,46 +1069,6 @@ mod MockMinigameTokenForLibs {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            let mut results = array![];
-            let mut i = 0;
-            loop {
-                if i >= mints.len() {
-                    break;
-                }
-                let params = mints.at(i);
-                let context_clone = match params.context {
-                    Option::Some(ctx) => Option::Some(ctx.clone()),
-                    Option::None => Option::None,
-                };
-                let client_url_clone = match params.client_url {
-                    Option::Some(url) => Option::Some(url.clone()),
-                    Option::None => Option::None,
-                };
-                let token_id = self
-                    .mint(
-                        *params.game_address,
-                        *params.player_name,
-                        *params.settings_id,
-                        *params.start,
-                        *params.end,
-                        *params.objective_id,
-                        context_clone,
-                        client_url_clone,
-                        *params.renderer_address,
-                        Option::None,
-                        *params.to,
-                        *params.soulbound,
-                        *params.paymaster,
-                        *params.salt,
-                        *params.metadata,
-                    );
-                results.append(token_id);
-                i += 1;
-            }
-            results
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -1120,7 +1081,7 @@ mod MockMinigameTokenForLibs {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,
@@ -1663,7 +1624,8 @@ mod MockMinigameTokenWithRegistry {
         IMINIGAME_TOKEN_ID, IMinigameToken,
     };
     use game_components_embeddable_game_standard::token::structs::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use openzeppelin_interfaces::introspection::ISRC5;
     use starknet::ContractAddress;
@@ -1930,46 +1892,6 @@ mod MockMinigameTokenWithRegistry {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            let mut results = array![];
-            let mut i = 0;
-            loop {
-                if i >= mints.len() {
-                    break;
-                }
-                let params = mints.at(i);
-                let context_clone = match params.context {
-                    Option::Some(ctx) => Option::Some(ctx.clone()),
-                    Option::None => Option::None,
-                };
-                let client_url_clone = match params.client_url {
-                    Option::Some(url) => Option::Some(url.clone()),
-                    Option::None => Option::None,
-                };
-                let token_id = self
-                    .mint(
-                        *params.game_address,
-                        *params.player_name,
-                        *params.settings_id,
-                        *params.start,
-                        *params.end,
-                        *params.objective_id,
-                        context_clone,
-                        client_url_clone,
-                        *params.renderer_address,
-                        Option::None,
-                        *params.to,
-                        *params.soulbound,
-                        *params.paymaster,
-                        *params.salt,
-                        *params.metadata,
-                    );
-                results.append(token_id);
-                i += 1;
-            }
-            results
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -1982,7 +1904,7 @@ mod MockMinigameTokenWithRegistry {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,

--- a/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
@@ -599,7 +599,8 @@ mod MockMinigameToken {
         IMINIGAME_TOKEN_ID, IMinigameToken,
     };
     use game_components_embeddable_game_standard::token::structs::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use openzeppelin_interfaces::introspection::ISRC5;
     use starknet::ContractAddress;
@@ -900,46 +901,6 @@ mod MockMinigameToken {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            let mut results = array![];
-            let mut i = 0;
-            loop {
-                if i >= mints.len() {
-                    break;
-                }
-                let params = mints.at(i);
-                let context_clone = match params.context {
-                    Option::Some(ctx) => Option::Some(ctx.clone()),
-                    Option::None => Option::None,
-                };
-                let client_url_clone = match params.client_url {
-                    Option::Some(url) => Option::Some(url.clone()),
-                    Option::None => Option::None,
-                };
-                let token_id = self
-                    .mint(
-                        *params.game_address,
-                        *params.player_name,
-                        *params.settings_id,
-                        *params.start,
-                        *params.end,
-                        *params.objective_id,
-                        context_clone,
-                        client_url_clone,
-                        *params.renderer_address,
-                        Option::None,
-                        *params.to,
-                        *params.soulbound,
-                        *params.paymaster,
-                        *params.salt,
-                        *params.metadata,
-                    );
-                results.append(token_id);
-                i += 1;
-            }
-            results
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -952,7 +913,7 @@ mod MockMinigameToken {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,

--- a/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
@@ -426,7 +426,8 @@ mod MockTokenContract {
         IMINIGAME_TOKEN_ID, IMinigameToken,
     };
     use game_components_embeddable_game_standard::token::structs::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use openzeppelin_interfaces::introspection::ISRC5;
     use starknet::ContractAddress;
@@ -722,46 +723,6 @@ mod MockTokenContract {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            let mut results = array![];
-            let mut i = 0;
-            loop {
-                if i >= mints.len() {
-                    break;
-                }
-                let params = mints.at(i);
-                let context_clone = match params.context {
-                    Option::Some(ctx) => Option::Some(ctx.clone()),
-                    Option::None => Option::None,
-                };
-                let client_url_clone = match params.client_url {
-                    Option::Some(url) => Option::Some(url.clone()),
-                    Option::None => Option::None,
-                };
-                let token_id = self
-                    .mint(
-                        *params.game_address,
-                        *params.player_name,
-                        *params.settings_id,
-                        *params.start,
-                        *params.end,
-                        *params.objective_id,
-                        context_clone,
-                        client_url_clone,
-                        *params.renderer_address,
-                        Option::None,
-                        *params.to,
-                        *params.soulbound,
-                        *params.paymaster,
-                        *params.salt,
-                        *params.metadata,
-                    );
-                results.append(token_id);
-                i += 1;
-            }
-            results
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -774,7 +735,7 @@ mod MockTokenContract {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,

--- a/packages/embeddable_game_standard/src/minigame/minigame.cairo
+++ b/packages/embeddable_game_standard/src/minigame/minigame.cairo
@@ -6,7 +6,6 @@ use game_components_embeddable_game_standard::registry::interface::{
 use game_components_embeddable_game_standard::token::interface::{
     IMinigameTokenDispatcher, IMinigameTokenDispatcherTrait,
 };
-use game_components_embeddable_game_standard::token::structs::MintParams;
 use openzeppelin_interfaces::erc721::{IERC721Dispatcher, IERC721DispatcherTrait};
 use starknet::ContractAddress;
 use crate::minigame::structs::MintGameParams;
@@ -201,13 +200,9 @@ pub fn mint_batch(
         contract_address: minigame_token_address,
     };
 
-    // Convert MintGameParams to MintParams
-    let mut mint_params_array = array![];
-    let mut index = 0;
-    loop {
-        if index >= mints.len() {
-            break;
-        }
+    let mut token_ids: Array<felt252> = array![];
+    let mut index: u32 = 0;
+    while index < mints.len() {
         let mint_game_param = mints.at(index);
 
         // Clone non-copyable Option types
@@ -215,36 +210,34 @@ pub fn mint_batch(
             Option::Some(ctx) => Option::Some(ctx.clone()),
             Option::None => Option::None,
         };
-
         let client_url_clone = match mint_game_param.client_url {
             Option::Some(url) => Option::Some(url.clone()),
             Option::None => Option::None,
         };
 
-        mint_params_array
-            .append(
-                MintParams {
-                    game_address: game_address,
-                    player_name: *mint_game_param.player_name,
-                    settings_id: *mint_game_param.settings_id,
-                    start: *mint_game_param.start,
-                    end: *mint_game_param.end,
-                    objective_id: *mint_game_param.objective_id,
-                    context: context_clone,
-                    client_url: client_url_clone,
-                    renderer_address: *mint_game_param.renderer_address,
-                    skills_address: *mint_game_param.skills_address,
-                    to: *mint_game_param.to,
-                    soulbound: *mint_game_param.soulbound,
-                    paymaster: *mint_game_param.paymaster,
-                    salt: *mint_game_param.salt,
-                    metadata: *mint_game_param.metadata,
-                },
+        let token_id = minigame_token_dispatcher
+            .mint(
+                game_address,
+                *mint_game_param.player_name,
+                *mint_game_param.settings_id,
+                *mint_game_param.start,
+                *mint_game_param.end,
+                *mint_game_param.objective_id,
+                context_clone,
+                client_url_clone,
+                *mint_game_param.renderer_address,
+                *mint_game_param.skills_address,
+                *mint_game_param.to,
+                *mint_game_param.soulbound,
+                *mint_game_param.paymaster,
+                *mint_game_param.salt,
+                *mint_game_param.metadata,
             );
+        token_ids.append(token_id);
         index += 1;
-    }
+    };
 
-    minigame_token_dispatcher.mint_batch(mint_params_array)
+    token_ids
 }
 
 /// Gets the player name for a game token

--- a/packages/embeddable_game_standard/src/minigame/minigame.cairo
+++ b/packages/embeddable_game_standard/src/minigame/minigame.cairo
@@ -235,7 +235,7 @@ pub fn mint_batch(
             );
         token_ids.append(token_id);
         index += 1;
-    };
+    }
 
     token_ids
 }

--- a/packages/embeddable_game_standard/src/minigame/tests/test_libs.cairo
+++ b/packages/embeddable_game_standard/src/minigame/tests/test_libs.cairo
@@ -528,10 +528,7 @@ fn test_mint_batch_empty_array() {
     let game_address = GAME_ADDRESS();
     let mints: Array<MintGameParams> = array![];
 
-    // Mock mint_batch to return empty array
-    let expected: Array<felt252> = array![];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
-
+    // No mock needed: the helper makes zero `mint` calls when the input is empty.
     let result = libs::mint_batch(token_address, game_address, mints);
 
     assert!(result.len() == 0, "Should return empty array");
@@ -560,8 +557,8 @@ fn test_mint_batch_single_mint() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 1);
 
     let result = libs::mint_batch(token_address, game_address, array![mint_params]);
 
@@ -626,15 +623,14 @@ fn test_mint_batch_multiple_mints() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1, 2, 3];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    // The helper now loops `mint()` per element; mock_call returns the same
+    // value each call so we just assert length.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 3);
 
     let result = libs::mint_batch(token_address, game_address, array![mint1, mint2, mint3]);
 
     assert!(result.len() == 3, "Should return 3 tokens");
-    assert!(*result.at(0) == 1, "First token should be 1");
-    assert!(*result.at(1) == 2, "Second token should be 2");
-    assert!(*result.at(2) == 3, "Third token should be 3");
 }
 
 // Test LIB-U-26: mint_batch with varied params
@@ -678,8 +674,8 @@ fn test_mint_batch_varied_params() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![10, 11];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 10;
+    mock_call(token_address, selector!("mint"), expected_token_id, 2);
 
     let result = libs::mint_batch(token_address, game_address, array![mint1, mint2]);
 
@@ -722,8 +718,8 @@ fn test_mint_batch_multiple_recipients() {
         i += 1;
     }
 
-    let expected: Array<felt252> = array![1, 2, 3, 4];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 4);
 
     let result = libs::mint_batch(token_address, game_address, mints);
 
@@ -921,7 +917,6 @@ fn test_mint_batch_large_batch() {
 
     // Create array with 10 mints
     let mut mints: Array<MintGameParams> = array![];
-    let mut expected: Array<felt252> = array![];
 
     let mut i: u32 = 0;
     loop {
@@ -947,11 +942,11 @@ fn test_mint_batch_large_batch() {
                     metadata: 0,
                 },
             );
-        expected.append((i + 1).into());
         i += 1;
     }
 
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 10);
 
     let result = libs::mint_batch(token_address, game_address, mints);
 
@@ -998,8 +993,8 @@ fn test_mint_batch_with_client_url() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1, 2];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 2);
 
     let result = libs::mint_batch(token_address, game_address, array![mint1, mint2]);
 
@@ -1324,8 +1319,8 @@ fn test_mint_batch_with_context() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1, 2];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 2);
 
     let result = libs::mint_batch(token_address, game_address, array![mint1, mint2]);
 
@@ -1396,8 +1391,8 @@ fn test_mint_batch_mixed_context() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1, 2, 3];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 3);
 
     let result = libs::mint_batch(token_address, game_address, array![mint1, mint2, mint3]);
 
@@ -1479,8 +1474,8 @@ fn test_mint_batch_with_empty_context_span() {
         metadata: 0,
     };
 
-    let expected: Array<felt252> = array![1];
-    mock_call(token_address, selector!("mint_batch"), expected.clone(), 1);
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 1);
 
     let result = libs::mint_batch(token_address, game_address, array![mint]);
 

--- a/packages/embeddable_game_standard/src/minigame/tests/test_minigame_component.cairo
+++ b/packages/embeddable_game_standard/src/minigame/tests/test_minigame_component.cairo
@@ -744,11 +744,12 @@ fn test_mint_game_with_time_bounds() {
 #[test]
 fn test_mint_game_batch_multiple() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![1, 2, 3];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -831,11 +832,12 @@ fn test_mint_game_batch_multiple() {
 #[test]
 fn test_mint_game_batch_empty() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -867,11 +869,12 @@ fn test_mint_game_batch_empty() {
 #[test]
 fn test_mint_game_batch_single() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![1];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -922,11 +925,12 @@ fn test_mint_game_batch_single() {
 #[test]
 fn test_mint_game_batch_mixed_params() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![1, 2];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -993,11 +997,12 @@ fn test_mint_game_batch_mixed_params() {
 #[test]
 fn test_mint_game_batch_multiple_recipients() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![1, 2, 3, 4];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -1759,11 +1764,12 @@ fn test_mint_game_with_context() {
 #[test]
 fn test_mint_game_batch_with_context() {
     let token_address = addr(0x123);
-    let expected_tokens: Array<felt252> = array![1, 2];
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 
@@ -2071,7 +2077,6 @@ fn test_initialize_with_external_extension_addresses() {
 #[test]
 fn test_mint_game_batch_large() {
     let token_address = addr(0x123);
-    let mut expected_tokens: Array<felt252> = array![];
     let mut mints: Array<MintGameParams> = array![];
 
     // Create 10 mints
@@ -2080,7 +2085,6 @@ fn test_mint_game_batch_large() {
         if i >= 10 {
             break;
         }
-        expected_tokens.append((i + 1).into());
         mints
             .append(
                 MintGameParams {
@@ -2105,7 +2109,9 @@ fn test_mint_game_batch_large() {
 
     mock_call(token_address, selector!("supports_interface"), true, 100);
     mock_call(token_address, selector!("game_registry_address"), addr(0x0), 100);
-    mock_call(token_address, selector!("mint_batch"), expected_tokens.clone(), 100);
+    // mint_batch helper now loops dispatcher.mint(); mock returns the same value each call.
+    let expected_token_id: felt252 = 1;
+    mock_call(token_address, selector!("mint"), expected_token_id, 100);
 
     let (minigame_dispatcher, minigame_init_dispatcher) = deploy_mock_game();
 

--- a/packages/embeddable_game_standard/src/token/AGENTS.md
+++ b/packages/embeddable_game_standard/src/token/AGENTS.md
@@ -4,15 +4,15 @@ ERC721 NFT representing playable game instances.
 
 ### Core Interface (IMinigameToken)
 
-**Interface ID:** `IMINIGAME_TOKEN_ID = 0xe67e1d4ee0d7c0cd75c9082845e0641ca255f8fe509d2b121db0b2287c4e8d`
+**Interface ID:** `IMINIGAME_TOKEN_ID = 0x246f614bd76b91c378a91877851f2ccdb99278e9fb77c782a22355059ce9906`
 
-| Method             | Signature                                  | Description                  |
-| ------------------ | ------------------------------------------ | ---------------------------- |
-| token_metadata     | `(token_id: u64) -> TokenMetadata`         | Get full token metadata      |
-| is_playable        | `(token_id: u64) -> bool`                  | Check if token can be played |
-| mint               | `(...params) -> u64`                       | Mint new token with config   |
-| mint_batch         | `(mints: Array<MintParams>) -> Array<u64>` | Batch mint tokens            |
-| update_game        | `(token_id: u64)`                          | Sync token state from game   |
+| Method                  | Signature                                                                                | Description                            |
+| ----------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------- |
+| token_metadata          | `(token_id: felt252) -> TokenMetadata`                                                   | Get full token metadata                |
+| is_playable             | `(token_id: felt252) -> bool`                                                            | Check if token can be played           |
+| mint                    | `(...params) -> felt252`                                                                 | Mint a single token                    |
+| mint_batch_recipients   | `(...shared params, recipients: Array<MintBatchRecipient>, ...) -> Array<felt252>`       | Batch mint, per-recipient counts       |
+| update_game             | `(token_id: felt252)`                                                                    | Sync token state from game             |
 
 **Batch views:** `*_batch` variants for all view functions (token_metadata, is_playable, settings_id, etc.)
 
@@ -69,7 +69,7 @@ struct TokenMetadata {
 }
 
 struct Lifecycle { start: u64, end: u64 }
-struct MintParams { to: ContractAddress, soulbound: bool, ... }
+struct MintBatchRecipient { to: ContractAddress, count: u16 }
 ```
 
 ### Extension Directory Structure

--- a/packages/embeddable_game_standard/src/token/interface.cairo
+++ b/packages/embeddable_game_standard/src/token/interface.cairo
@@ -10,7 +10,7 @@ pub use game_components_interfaces::token::{
 };
 use starknet::ContractAddress;
 use crate::token::structs::{
-    MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+    MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
 };
 
 #[starknet::interface]
@@ -71,7 +71,6 @@ pub trait IMinigameTokenMixin<TState> {
     fn update_player_name(ref self: TState, token_id: felt252, name: felt252);
 
     // Batch write functions
-    fn mint_batch(ref self: TState, mints: Array<MintParams>) -> Array<felt252>;
     fn mint_batch_recipients(
         ref self: TState,
         game_address: ContractAddress,
@@ -84,7 +83,7 @@ pub trait IMinigameTokenMixin<TState> {
         client_url: Option<ByteArray>,
         renderer_address: Option<ContractAddress>,
         skills_address: Option<ContractAddress>,
-        recipients: Array<ContractAddress>,
+        recipients: Array<MintBatchRecipient>,
         soulbound: bool,
         paymaster: bool,
         salt: u16,

--- a/packages/embeddable_game_standard/src/token/structs.cairo
+++ b/packages/embeddable_game_standard/src/token/structs.cairo
@@ -2,7 +2,8 @@ pub use game_components_interfaces::structs::metagame::GameContextDetails;
 
 // Re-export structs from interfaces for backward compatibility
 pub use game_components_interfaces::structs::token::{
-    Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+    Lifecycle, MintBatchRecipient, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata,
+    TokenMutableState,
 };
 use starknet::storage_access::StorePacking;
 

--- a/packages/embeddable_game_standard/src/token/tests/test_batch_views.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_batch_views.cairo
@@ -801,8 +801,7 @@ fn test_mint_batch_recipients_multiple() {
 
     // One token to each of Alice, Bob, Charlie.
     let recipients = array![
-        MintBatchRecipient { to: ALICE(), count: 1 },
-        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: ALICE(), count: 1 }, MintBatchRecipient { to: BOB(), count: 1 },
         MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
     let token_ids = test_contracts
@@ -840,8 +839,7 @@ fn test_mint_batch_recipients_with_counts() {
 
     // 3 tokens to Alice, 2 tokens to Bob — exercises the per-recipient count path.
     let recipients = array![
-        MintBatchRecipient { to: ALICE(), count: 3 },
-        MintBatchRecipient { to: BOB(), count: 2 },
+        MintBatchRecipient { to: ALICE(), count: 3 }, MintBatchRecipient { to: BOB(), count: 2 },
     ];
     let token_ids = test_contracts
         .test_token

--- a/packages/embeddable_game_standard/src/token/tests/test_batch_views.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_batch_views.cairo
@@ -735,42 +735,59 @@ fn test_batch_matches_individual_calls() {
 // BATCH WRITE FUNCTION TESTS
 // ============================================================================
 
-use crate::token::structs::{MintParams, PlayerNameUpdate};
+use crate::token::structs::{MintBatchRecipient, PlayerNameUpdate};
 
 #[test]
-#[should_panic(expected: "MinigameToken: mints array cannot be empty")]
-fn test_mint_batch_empty_panics() {
+#[should_panic(expected: "MinigameToken: recipients array cannot be empty")]
+fn test_mint_batch_recipients_empty_panics() {
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![];
-    test_contracts.test_token.mint_batch(mints);
+    let recipients: Array<MintBatchRecipient> = array![];
+    test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 }
 
 #[test]
-fn test_mint_batch_single() {
+fn test_mint_batch_recipients_single() {
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Alice'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-    ];
-
-    let token_ids = test_contracts.test_token.mint_batch(mints);
+    let recipients = array![MintBatchRecipient { to: ALICE(), count: 1 }];
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::Some('Alice'),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 
     assert!(token_ids.len() == 1, "Should return one token_id");
     let token_id = *token_ids.at(0);
@@ -779,135 +796,74 @@ fn test_mint_batch_single() {
 }
 
 #[test]
-fn test_mint_batch_multiple() {
+fn test_mint_batch_recipients_multiple() {
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Alice'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Bob'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: BOB(),
-            soulbound: true,
-            paymaster: false,
-            salt: 1,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::None,
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: CHARLIE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 2,
-            metadata: 0,
-        },
+    // One token to each of Alice, Bob, Charlie.
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 1 },
+        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
-
-    let token_ids = test_contracts.test_token.mint_batch(mints);
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 
     assert!(token_ids.len() == 3, "Should return three token_ids");
-
-    // Verify each token
     let token_id1 = *token_ids.at(0);
     let token_id2 = *token_ids.at(1);
     let token_id3 = *token_ids.at(2);
-
-    assert!(test_contracts.test_token.player_name(token_id1) == 'Alice', "Token 1 name");
-    assert!(test_contracts.test_token.player_name(token_id2) == 'Bob', "Token 2 name");
-    assert!(test_contracts.test_token.player_name(token_id3) == 0, "Token 3 should have no name");
-
     assert!(!test_contracts.test_token.is_soulbound(token_id1), "Token 1 not soulbound");
-    assert!(test_contracts.test_token.is_soulbound(token_id2), "Token 2 soulbound");
+    assert!(!test_contracts.test_token.is_soulbound(token_id2), "Token 2 not soulbound");
     assert!(!test_contracts.test_token.is_soulbound(token_id3), "Token 3 not soulbound");
 }
 
 #[test]
-fn test_mint_batch_different_settings() {
+fn test_mint_batch_recipients_with_counts() {
     let test_contracts = setup();
 
-    // Test minting with different settings per token
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Player1'),
-            settings_id: Option::None,
-            start: Option::Some(1000),
-            end: Option::Some(2000),
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Player2'),
-            settings_id: Option::None,
-            start: Option::Some(3000),
-            end: Option::Some(4000),
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: BOB(),
-            soulbound: true,
-            paymaster: false,
-            salt: 1,
-            metadata: 0,
-        },
+    // 3 tokens to Alice, 2 tokens to Bob — exercises the per-recipient count path.
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 3 },
+        MintBatchRecipient { to: BOB(), count: 2 },
     ];
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 
-    let token_ids = test_contracts.test_token.mint_batch(mints);
-
-    assert!(token_ids.len() == 2, "Should return two token_ids");
-
-    let token_id1 = *token_ids.at(0);
-    let token_id2 = *token_ids.at(1);
-
-    // Verify tokens have different properties
-    assert!(test_contracts.test_token.player_name(token_id1) == 'Player1', "Token 1 name");
-    assert!(test_contracts.test_token.player_name(token_id2) == 'Player2', "Token 2 name");
-    assert!(!test_contracts.test_token.is_soulbound(token_id1), "Token 1 not soulbound");
-    assert!(test_contracts.test_token.is_soulbound(token_id2), "Token 2 soulbound");
+    assert!(token_ids.len() == 5, "Should mint 5 tokens total");
 }
 
 #[test]

--- a/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
@@ -1119,8 +1119,7 @@ fn test_mint_batch_recipients_multiple() {
     let test_contracts = setup();
 
     let recipients = array![
-        MintBatchRecipient { to: ALICE(), count: 1 },
-        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: ALICE(), count: 1 }, MintBatchRecipient { to: BOB(), count: 1 },
         MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
     let token_ids = test_contracts
@@ -2100,8 +2099,7 @@ fn test_event_batch_mint_multiple_transfers() {
     let mut spy = spy_events();
 
     let recipients = array![
-        MintBatchRecipient { to: ALICE(), count: 1 },
-        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: ALICE(), count: 1 }, MintBatchRecipient { to: BOB(), count: 1 },
         MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
     test_contracts

--- a/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_core_token.cairo
@@ -10,7 +10,7 @@ use snforge_std::{
 };
 use starknet::ContractAddress;
 use crate::token::interface::{IMINIGAME_TOKEN_ID, IMinigameTokenMixinDispatcherTrait};
-use crate::token::structs::{MintParams, PlayerNameUpdate};
+use crate::token::structs::{MintBatchRecipient, PlayerNameUpdate};
 use crate::token::token_component::CoreTokenComponent;
 use super::mocks::mock_game::IMockGameDispatcherTrait;
 use super::setup::{
@@ -1058,199 +1058,160 @@ fn test_mint_with_renderer_address() {
 // ============================================================================
 
 #[test]
-#[should_panic(expected: "MinigameToken: mints array cannot be empty")]
-fn test_mint_batch_empty_array_panics() {
-    // TC-MB-001: Empty array
+#[should_panic(expected: "MinigameToken: recipients array cannot be empty")]
+fn test_mint_batch_recipients_empty_array_panics() {
+    // TC-MBR-001: Empty recipients array
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![];
-    test_contracts.test_token.mint_batch(mints);
+    let recipients: Array<MintBatchRecipient> = array![];
+    test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 }
 
 #[test]
-fn test_mint_batch_single_mint() {
-    // TC-MB-002: Single mint in batch
+fn test_mint_batch_recipients_single() {
+    // TC-MBR-002: Single recipient, count=1
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Player1'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-    ];
-
-    let token_ids = test_contracts.test_token.mint_batch(mints);
+    let recipients = array![MintBatchRecipient { to: ALICE(), count: 1 }];
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::Some('Player1'),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
     assert!(token_ids.len() == 1, "Should return one token_id");
 }
 
 #[test]
-fn test_mint_batch_multiple_mints() {
-    // TC-MB-003: Multiple mints
+fn test_mint_batch_recipients_multiple() {
+    // TC-MBR-003: Multiple recipients, count=1 each
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Alice'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Bob'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: BOB(),
-            soulbound: true,
-            paymaster: false,
-            salt: 1,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Charlie'),
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: CHARLIE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 2,
-            metadata: 0,
-        },
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 1 },
+        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
-
-    let token_ids = test_contracts.test_token.mint_batch(mints);
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
     assert!(token_ids.len() == 3, "Should return 3 token_ids");
-
-    // Verify unique
     assert!(*token_ids.at(0) != *token_ids.at(1), "IDs should be unique");
     assert!(*token_ids.at(1) != *token_ids.at(2), "IDs should be unique");
 }
 
 #[test]
-fn test_mint_batch_mixed_settings() {
-    // TC-MB-004: Mixed settings per token
+fn test_mint_batch_recipients_with_lifecycle() {
+    // TC-MBR-004: Shared lifecycle across recipients
     let test_contracts = setup();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::Some('Player1'),
-            settings_id: Option::None,
-            start: Option::Some(CURRENT_TIME),
-            end: Option::Some(FUTURE_TIME),
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::None,
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: BOB(),
-            soulbound: true,
-            paymaster: false,
-            salt: 1,
-            metadata: 0,
-        },
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 1 }, MintBatchRecipient { to: BOB(), count: 1 },
     ];
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::Some('Player1'),
+            Option::None,
+            Option::Some(CURRENT_TIME),
+            Option::Some(FUTURE_TIME),
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 
-    let token_ids = test_contracts.test_token.mint_batch(mints);
-
-    // Verify different settings
     let token_id1 = *token_ids.at(0);
     let token_id2 = *token_ids.at(1);
-
-    assert!(!test_contracts.test_token.is_soulbound(token_id1), "Token 1 not soulbound");
-    assert!(test_contracts.test_token.is_soulbound(token_id2), "Token 2 soulbound");
     assert!(
-        test_contracts.test_token.player_name(token_id1) == 'Player1', "Token 1 has player name",
+        test_contracts.test_token.player_name(token_id1) == 'Player1', "Token 1 player name set",
     );
-    assert!(test_contracts.test_token.player_name(token_id2) == 0, "Token 2 has no player name");
+    assert!(
+        test_contracts.test_token.player_name(token_id2) == 'Player1', "Token 2 shares player name",
+    );
 }
 
 #[test]
-fn test_mint_batch_large() {
-    // TC-MB-005: Large batch
+fn test_mint_batch_recipients_with_counts() {
+    // TC-MBR-005: Per-recipient counts > 1 (the case mint_batch_to was for)
     let test_contracts = setup();
 
-    let mut mints: Array<MintParams> = array![];
-    let mut i: u32 = 0;
-    while i < 10 {
-        mints
-            .append(
-                MintParams {
-                    game_address: test_contracts.minigame.contract_address,
-                    player_name: Option::None,
-                    settings_id: Option::None,
-                    start: Option::None,
-                    end: Option::None,
-                    objective_id: Option::None,
-                    context: Option::None,
-                    client_url: Option::None,
-                    renderer_address: Option::None,
-                    skills_address: Option::None,
-                    to: ALICE(),
-                    soulbound: false,
-                    paymaster: false,
-                    salt: i.try_into().unwrap(),
-                    metadata: 0,
-                },
-            );
-        i += 1;
-    }
-
-    let token_ids = test_contracts.test_token.mint_batch(mints);
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 6 }, MintBatchRecipient { to: BOB(), count: 4 },
+    ];
+    let token_ids = test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
     assert!(token_ids.len() == 10, "Should return 10 token_ids");
 }
 
@@ -2138,61 +2099,30 @@ fn test_event_batch_mint_multiple_transfers() {
     let test_contracts = setup();
     let mut spy = spy_events();
 
-    let mints: Array<MintParams> = array![
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::None,
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: ALICE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 0,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::None,
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: BOB(),
-            soulbound: false,
-            paymaster: false,
-            salt: 1,
-            metadata: 0,
-        },
-        MintParams {
-            game_address: test_contracts.minigame.contract_address,
-            player_name: Option::None,
-            settings_id: Option::None,
-            start: Option::None,
-            end: Option::None,
-            objective_id: Option::None,
-            context: Option::None,
-            client_url: Option::None,
-            renderer_address: Option::None,
-            skills_address: Option::None,
-            to: CHARLIE(),
-            soulbound: false,
-            paymaster: false,
-            salt: 2,
-            metadata: 0,
-        },
+    let recipients = array![
+        MintBatchRecipient { to: ALICE(), count: 1 },
+        MintBatchRecipient { to: BOB(), count: 1 },
+        MintBatchRecipient { to: CHARLIE(), count: 1 },
     ];
-
-    test_contracts.test_token.mint_batch(mints);
+    test_contracts
+        .test_token
+        .mint_batch_recipients(
+            test_contracts.minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            recipients,
+            false,
+            false,
+            0,
+            0,
+        );
 
     let events = spy.get_events();
     assert!(events.events.span().len() >= 3, "Should emit at least 3 Transfer events");

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -28,7 +28,7 @@ pub mod CoreTokenComponent {
         IMinigameToken,
     };
     use crate::token::structs::{
-        LifecycleStorePacking, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        LifecycleStorePacking, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
         TokenMutableState, TokenMutableStateStorePacking, extract_tx_hash_bits, pack_token_id,
         to_token_metadata, unpack_game_id, unpack_minted_by, unpack_objective_id, unpack_soulbound,
         unpack_token_id,
@@ -501,42 +501,18 @@ pub mod CoreTokenComponent {
                 )
         }
 
-        /// Batch mint with full per-token parameters.
-        fn mint_batch(
-            ref self: ComponentState<TContractState>, mut mints: Array<MintParams>,
-        ) -> Array<felt252> {
-            assert!(mints.len() > 0, "MinigameToken: mints array cannot be empty");
-            let mut token_ids: Array<felt252> = ArrayTrait::new();
-            loop {
-                match mints.pop_front() {
-                    Option::Some(params) => {
-                        let token_id = self
-                            .mint_game(
-                                params.game_address,
-                                params.player_name,
-                                params.settings_id,
-                                params.start,
-                                params.end,
-                                params.objective_id,
-                                params.context,
-                                params.client_url,
-                                params.renderer_address,
-                                params.skills_address,
-                                params.to,
-                                params.soulbound,
-                                params.paymaster,
-                                params.salt,
-                                params.metadata,
-                            );
-                        token_ids.append(token_id);
-                    },
-                    Option::None => { break; },
-                }
-            }
-            token_ids
-        }
-
-        /// Batch mint identical tokens to multiple recipients with auto-incrementing salt.
+        /// Batch mint identical tokens to one or more recipients with per-recipient counts.
+        ///
+        /// All recipients share the same mint configuration (game, settings, objective,
+        /// lifecycle, context, renderer, skills, soulbound, paymaster, metadata). Each
+        /// `MintBatchRecipient { to, count }` mints `count` tokens to `to`. Salt is a
+        /// single global counter across the batch (`salt + i` for `i in 0..sum(counts)`);
+        /// the recipient is not encoded in `token_id`, so salts must be globally unique
+        /// within the tx.
+        ///
+        /// Versus calling `mint`/`mint_game` per token, this hoists the SRC5 game check,
+        /// settings/objective validation, minter registration, lifecycle math, and tx
+        /// info reads to a single pre-loop pass — paying them once for the whole batch.
         fn mint_batch_recipients(
             ref self: ComponentState<TContractState>,
             game_address: ContractAddress,
@@ -549,58 +525,169 @@ pub mod CoreTokenComponent {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            mut recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,
             metadata: u16,
         ) -> Array<felt252> {
-            let count = recipients.len();
-            assert!(count > 0, "MinigameToken: recipients array cannot be empty");
-            // Ensure salt won't overflow u16 during auto-increment
-            let max_salt: u32 = salt.into() + count - 1;
+            let recipient_count = recipients.len();
+            assert!(recipient_count > 0, "MinigameToken: recipients array cannot be empty");
+
+            // Sum per-recipient counts and bound the global salt counter.
+            // The salt field in pack_token_id is 10 bits, so salt + total - 1 <= 0x3FF.
+            let mut total_tokens: u32 = 0;
+            let mut sum_idx: u32 = 0;
+            while sum_idx < recipient_count {
+                let r: @MintBatchRecipient = recipients.at(sum_idx);
+                let c: u16 = *r.count;
+                assert!(c > 0, "MinigameToken: per-recipient count must be > 0");
+                total_tokens += c.into();
+                sum_idx += 1;
+            };
+            let max_salt: u32 = salt.into() + total_tokens - 1;
             assert!(
-                max_salt <= 0xFFFF, "MinigameToken: salt overflow, reduce base salt or recipients",
+                max_salt <= 0x3FF,
+                "MinigameToken: salt overflow (salt + total tokens - 1 must be <= 1023)",
             );
 
+            // =================================================================
+            // HOIST: invariants shared across the entire batch
+            // =================================================================
+            let caller = get_caller_address();
+            let current_time = get_block_timestamp();
+            let tx_hash_bits = extract_tx_hash_bits(
+                get_tx_info().unbox().transaction_hash,
+            );
+
+            // Lifecycle math is identical for every token; compute once.
+            // See mint_game for the rationale on the end-in-future check and the
+            // effective_start clamp.
+            let lifecycle = token_state::create_lifecycle_with_defaults(start, end);
+            lifecycle.validate();
+            assert!(
+                lifecycle.end == 0
+                    || (lifecycle.end > current_time && lifecycle.end > lifecycle.start),
+                "MinigameToken: Lifecycle end must be in the future and after start",
+            );
+            let effective_start = if lifecycle.start > current_time {
+                lifecycle.start
+            } else {
+                current_time
+            };
+            let start_delay: u32 = (effective_start - current_time).try_into().unwrap();
+            let end_delay: u32 = if lifecycle.end > effective_start {
+                (lifecycle.end - effective_start).try_into().unwrap()
+            } else {
+                0
+            };
+
+            // Single SRC5 / registry round-trip for the entire batch.
+            let (final_game_address, game_id) = self
+                .validate_and_process_game_address(game_address);
+
+            let contract = self.get_contract();
+            let mut contract_self = self.get_contract_mut();
+
+            // Each of these is at most one cross-contract call per batch (vs. one
+            // per token in the old per-recipient loop).
+            let validated_settings_id = match settings_id {
+                Option::Some(sid) => {
+                    SettingsOpt::validate_settings(contract, final_game_address, sid);
+                    sid
+                },
+                Option::None => 0,
+            };
+            let validated_objective_id: u32 = match objective_id {
+                Option::Some(obj_id) => {
+                    ObjectivesOpt::validate_objective(contract, final_game_address, obj_id);
+                    obj_id
+                },
+                Option::None => 0,
+            };
+
+            // Caller is fixed for the whole batch — register once.
+            let minted_by = MinterOpt::add_minter(ref contract_self, caller);
+            let has_context = context.is_some();
+
+            // =================================================================
+            // LOOP: per-token work only
+            // =================================================================
             let mut token_ids: Array<felt252> = ArrayTrait::new();
-            let mut index: u16 = 0;
-            loop {
-                match recipients.pop_front() {
-                    Option::Some(to) => {
-                        let current_salt = salt + index;
-                        let ctx = match @context {
-                            Option::Some(c) => Option::Some(c.clone()),
-                            Option::None => Option::None,
-                        };
-                        let url = match @client_url {
-                            Option::Some(u) => Option::Some(u.clone()),
-                            Option::None => Option::None,
-                        };
-                        let token_id = self
-                            .mint_game(
-                                game_address,
-                                player_name,
-                                settings_id,
-                                start,
-                                end,
-                                objective_id,
-                                ctx,
-                                url,
-                                renderer_address,
-                                skills_address,
-                                to,
-                                soulbound,
-                                paymaster,
-                                current_salt,
-                                metadata,
+            let mut salt_offset: u16 = 0;
+            let mut r_idx: u32 = 0;
+            while r_idx < recipient_count {
+                let r: @MintBatchRecipient = recipients.at(r_idx);
+                let to: ContractAddress = *r.to;
+                let count: u16 = *r.count;
+
+                let mut k: u16 = 0;
+                while k < count {
+                    let current_salt = salt + salt_offset;
+
+                    let final_token_id = pack_token_id(
+                        game_id.try_into().unwrap(),
+                        minted_by,
+                        validated_settings_id,
+                        current_time,
+                        start_delay,
+                        end_delay,
+                        validated_objective_id,
+                        soulbound,
+                        has_context,
+                        paymaster,
+                        tx_hash_bits,
+                        current_salt,
+                        metadata,
+                    );
+
+                    // Per-token extension hooks (context, renderer, skills).
+                    match @context {
+                        Option::Some(c) => {
+                            ContextOpt::on_context_set(
+                                ref contract_self, caller, final_token_id, c.clone(),
                             );
-                        token_ids.append(token_id);
-                        index += 1;
-                    },
-                    Option::None => { break; },
-                }
-            }
+                        },
+                        Option::None => {},
+                    };
+                    match renderer_address {
+                        Option::Some(raddr) => {
+                            RendererOpt::set_token_renderer(
+                                ref contract_self, final_token_id, raddr,
+                            );
+                        },
+                        Option::None => {},
+                    };
+                    match skills_address {
+                        Option::Some(addr) => {
+                            SkillsOpt::set_token_skills(ref contract_self, final_token_id, addr);
+                        },
+                        Option::None => {},
+                    };
+
+                    // Per-token storage (player name, client url).
+                    if let Option::Some(name) = player_name {
+                        self.token_player_names.entry(final_token_id).write(name);
+                    }
+                    match @client_url {
+                        Option::Some(u) => {
+                            self.token_client_url.entry(final_token_id).write(u.clone());
+                        },
+                        Option::None => {},
+                    };
+
+                    // Mint ERC721.
+                    let mut c_mut = self.get_contract_mut();
+                    let mut erc721_component = ERC721::get_component_mut(ref c_mut);
+                    erc721_component.mint(to, final_token_id.into());
+
+                    token_ids.append(final_token_id);
+                    salt_offset += 1;
+                    k += 1;
+                };
+                r_idx += 1;
+            };
+
             token_ids
         }
 

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -544,7 +544,7 @@ pub mod CoreTokenComponent {
                 assert!(c > 0, "MinigameToken: per-recipient count must be > 0");
                 total_tokens += c.into();
                 sum_idx += 1;
-            };
+            }
             let max_salt: u32 = salt.into() + total_tokens - 1;
             assert!(
                 max_salt <= 0x3FF,
@@ -556,9 +556,7 @@ pub mod CoreTokenComponent {
             // =================================================================
             let caller = get_caller_address();
             let current_time = get_block_timestamp();
-            let tx_hash_bits = extract_tx_hash_bits(
-                get_tx_info().unbox().transaction_hash,
-            );
+            let tx_hash_bits = extract_tx_hash_bits(get_tx_info().unbox().transaction_hash);
 
             // Lifecycle math is identical for every token; compute once.
             // See mint_game for the rationale on the end-in-future check and the
@@ -649,7 +647,7 @@ pub mod CoreTokenComponent {
                             );
                         },
                         Option::None => {},
-                    };
+                    }
                     match renderer_address {
                         Option::Some(raddr) => {
                             RendererOpt::set_token_renderer(
@@ -657,13 +655,13 @@ pub mod CoreTokenComponent {
                             );
                         },
                         Option::None => {},
-                    };
+                    }
                     match skills_address {
                         Option::Some(addr) => {
                             SkillsOpt::set_token_skills(ref contract_self, final_token_id, addr);
                         },
                         Option::None => {},
-                    };
+                    }
 
                     // Per-token storage (player name, client url).
                     if let Option::Some(name) = player_name {
@@ -674,7 +672,7 @@ pub mod CoreTokenComponent {
                             self.token_client_url.entry(final_token_id).write(u.clone());
                         },
                         Option::None => {},
-                    };
+                    }
 
                     // Mint ERC721.
                     let mut c_mut = self.get_contract_mut();
@@ -684,9 +682,9 @@ pub mod CoreTokenComponent {
                     token_ids.append(final_token_id);
                     salt_offset += 1;
                     k += 1;
-                };
+                }
                 r_idx += 1;
-            };
+            }
 
             token_ids
         }

--- a/packages/interfaces/src/AGENTS.md
+++ b/packages/interfaces/src/AGENTS.md
@@ -18,7 +18,7 @@ Single source of truth for all game component interface definitions. Other packa
 
 | Module | Structs |
 |--------|---------|
-| `structs/token` | `TokenMetadata`, `Lifecycle`, `MintParams`, `PlayerNameUpdate` |
+| `structs/token` | `TokenMetadata`, `Lifecycle`, `MintBatchRecipient`, `MintParams`, `PlayerNameUpdate` |
 | `structs/minigame` | `GameDetail`, `MintGameParams`, `GameSettingDetails`, `GameSetting`, `GameObjective` |
 | `structs/metagame` | `GameContextDetails`, `GameContext` |
 | `structs/leaderboard` | `LeaderboardConfig`, `LeaderboardEntry`, `LeaderboardResult`, `LeaderboardStoreConfig` |
@@ -71,7 +71,7 @@ let supports = src5_dispatcher.supports_interface(IMINIGAME_SETTINGS_ID);
 
 ```cairo
 use game_components_interfaces::{
-    TokenMetadata, Lifecycle, MintParams,
+    TokenMetadata, Lifecycle, MintBatchRecipient,
     GameMetadata, GameDetail,
     LeaderboardEntry, LeaderboardConfig,
 };

--- a/packages/interfaces/src/lib.cairo
+++ b/packages/interfaces/src/lib.cairo
@@ -101,8 +101,8 @@ pub use registry::{
 pub use structs::{
     GameContext, GameContextDetails, GameDetail, GameFeeInfo, GameMetadata, GameObjective,
     GameObjectiveDetails, GameSetting, GameSettingDetails, LeaderboardConfig, LeaderboardEntry,
-    LeaderboardResult, LeaderboardStoreConfig, Lifecycle, MintGameParams, MintParams,
-    PlayerNameUpdate, TokenMetadata,
+    LeaderboardResult, LeaderboardStoreConfig, Lifecycle, MintBatchRecipient, MintGameParams,
+    MintParams, PlayerNameUpdate, TokenMetadata,
 };
 
 // Token

--- a/packages/interfaces/src/structs.cairo
+++ b/packages/interfaces/src/structs.cairo
@@ -17,5 +17,6 @@ pub use minigame::{
 };
 pub use registry::{GameFeeInfo, GameMetadata};
 pub use token::{
-    Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+    Lifecycle, MintBatchRecipient, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata,
+    TokenMutableState,
 };

--- a/packages/interfaces/src/structs/token.cairo
+++ b/packages/interfaces/src/structs/token.cairo
@@ -69,6 +69,16 @@ pub struct MintParams {
     pub metadata: u16,
 }
 
+/// Per-recipient parameters for `mint_batch_recipients`.
+/// Mints `count` tokens to `to` with the shared mint config supplied by the caller.
+/// The salt provided to `mint_batch_recipients` increments by one per minted token
+/// (across all recipients) for deterministic, collision-free token IDs.
+#[derive(Copy, Drop, Serde)]
+pub struct MintBatchRecipient {
+    pub to: ContractAddress,
+    pub count: u16,
+}
+
 /// Per-token name update parameters for batch name updates
 #[derive(Copy, Drop, Serde)]
 pub struct PlayerNameUpdate {

--- a/packages/interfaces/src/token/core.cairo
+++ b/packages/interfaces/src/token/core.cairo
@@ -2,13 +2,16 @@
 use starknet::ContractAddress;
 use crate::structs::metagame::GameContextDetails;
 use crate::structs::token::{
-    MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+    MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
 };
 
-/// SNIP-5 interface ID derived via src5_rs: XOR of extended function selectors
-/// Includes skills_address view function. Run `src5_rs parse` for full derivation.
+/// SNIP-5 interface ID derived via src5_rs: XOR of extended function selectors.
+///
+/// Surface includes `mint`, `mint_batch_recipients(Array<MintBatchRecipient>, ...)`,
+/// `update_game`, and the read/batch-read methods. Run `src5_rs parse` against a
+/// stripped copy of this trait (see packages/interfaces/src/AGENTS.md) to rederive.
 pub const IMINIGAME_TOKEN_ID: felt252 =
-    0x21c51b9820202309d87ff5d316b17b2d9280f2db9fd8fc2c6120c3a60869e49;
+    0x246f614bd76b91c378a91877851f2ccdb99278e9fb77c782a22355059ce9906;
 
 #[starknet::interface]
 pub trait IMinigameToken<TState> {
@@ -63,12 +66,16 @@ pub trait IMinigameToken<TState> {
         salt: u16,
         metadata: u16,
     ) -> felt252;
-    /// Batch mint with full per-token parameters.
-    /// Each MintParams contains all configuration for that token.
-    fn mint_batch(ref self: TState, mints: Array<MintParams>) -> Array<felt252>;
-
-    /// Batch mint identical tokens to multiple recipients.
-    /// Shares all parameters across recipients and auto-increments salt (base_salt + index).
+    /// Batch mint identical tokens to one or more recipients with per-recipient counts.
+    ///
+    /// All recipients share the same mint configuration (game, settings, objective,
+    /// lifecycle, context, renderer, skills, soulbound, paymaster, metadata).
+    /// Each `MintBatchRecipient { to, count }` mints `count` tokens to `to`.
+    ///
+    /// Salt assignment is a single global counter across the batch (`base_salt + i`,
+    /// `i` in `0..sum(counts)`). Token ids do not encode the recipient, so salts
+    /// must be globally unique within the tx — `salt + sum(counts) - 1 <= 0x3FF`
+    /// (10-bit salt field in `pack_token_id`).
     fn mint_batch_recipients(
         ref self: TState,
         game_address: ContractAddress,
@@ -81,7 +88,7 @@ pub trait IMinigameToken<TState> {
         client_url: Option<ByteArray>,
         renderer_address: Option<ContractAddress>,
         skills_address: Option<ContractAddress>,
-        recipients: Array<ContractAddress>,
+        recipients: Array<MintBatchRecipient>,
         soulbound: bool,
         paymaster: bool,
         salt: u16,

--- a/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
+++ b/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
@@ -997,7 +997,8 @@ mod MockMinigameTokenForTicketBooth {
     use core::num::traits::Zero;
     use game_components_interfaces::structs::metagame::GameContextDetails;
     use game_components_interfaces::structs::token::{
-        Lifecycle, MintParams, PlayerNameUpdate, TokenFullState, TokenMetadata, TokenMutableState,
+        Lifecycle, MintBatchRecipient, PlayerNameUpdate, TokenFullState, TokenMetadata,
+        TokenMutableState,
     };
     use game_components_interfaces::token::{IMINIGAME_TOKEN_ID, IMinigameToken};
     use openzeppelin_interfaces::introspection::ISRC5;
@@ -1176,10 +1177,6 @@ mod MockMinigameTokenForTicketBooth {
             token_id
         }
 
-        fn mint_batch(ref self: ContractState, mints: Array<MintParams>) -> Array<felt252> {
-            array![]
-        }
-
         fn mint_batch_recipients(
             ref self: ContractState,
             game_address: ContractAddress,
@@ -1192,7 +1189,7 @@ mod MockMinigameTokenForTicketBooth {
             client_url: Option<ByteArray>,
             renderer_address: Option<ContractAddress>,
             skills_address: Option<ContractAddress>,
-            recipients: Array<ContractAddress>,
+            recipients: Array<MintBatchRecipient>,
             soulbound: bool,
             paymaster: bool,
             salt: u16,


### PR DESCRIPTION
## Summary

- Replaces `mint_batch_recipients(recipients: Array<ContractAddress>, ...)` with `mint_batch_recipients(recipients: Array<MintBatchRecipient { to, count }>, ...)` and hoists all batch-invariant work (caller, block timestamp, tx hash, lifecycle math, SRC5 game check, settings/objective validation, minter registration) above the per-token loop. Per extra token this saves ~3 cross-contract calls plus a minter storage read versus the old per-recipient loop into `mint_game`.
- **Drops `IMinigameToken::mint_batch(Array<MintParams>)`**. The new `mint_batch_recipients` covers all real use cases; the only on-chain caller (`minigame::mint_batch` → qr-drops) was using it for the homogeneous shared-params case the optimized path now handles. `minigame::mint_batch` is rewritten to loop `dispatcher.mint()` so its callers keep compiling unchanged.
- Fixes a silent salt-collision bug in `mint_batch_recipients`: the `salt` field in `pack_token_id` is 10 bits (max `0x3FF`), but the overflow assert checked against `0xFFFF`. Large salts wrapped and caused token-id collisions.
- Recomputes `IMINIGAME_TOKEN_ID` (interface surface changed):
  `0x246f614bd76b91c378a91877851f2ccdb99278e9fb77c782a22355059ce9906`

## Gas wins

For an N-token batch with shared config, the new path replaces N copies of the validation prologue (in the old `mint_batch` / `mint_batch_recipients` path) with one. Concretely, for each extra token we skip:

- 1 SRC5 `supports_interface(IMINIGAME_ID)` dispatcher call (game validation)
- 1 settings-validate dispatcher call (when `settings_id` is set)
- 1 objective-validate dispatcher call (when `objective_id` is set)
- 1 minter storage read in `add_minter`
- the lifecycle compute and `effective_start` clamp
- the `get_tx_info` / `extract_tx_hash_bits` work

Per-recipient counts (`{alice, 5}, {bob, 3}`) further amortize the per-recipient address handling.

## API

```cairo
#[derive(Copy, Drop, Serde)]
pub struct MintBatchRecipient {
    pub to: ContractAddress,
    pub count: u16,
}

fn mint_batch_recipients(
    ref self: TState,
    game_address: ContractAddress,
    /* shared mint config: player_name, settings_id, start, end, objective_id,
       context, client_url, renderer_address, skills_address */
    recipients: Array<MintBatchRecipient>,
    soulbound: bool,
    paymaster: bool,
    salt: u16,
    metadata: u16,
) -> Array<felt252>;
```

Salt assignment is a single global counter across the batch (`salt + i` for `i in 0..sum(counts)`); the recipient is not encoded in `token_id`, so salts must be unique within the tx — `salt + sum(counts) - 1 <= 0x3FF`.

## Migration

1. Deploy the new class and `upgrade(...)` as usual — no storage layout change.
2. After the upgrade, call `src5.register_interface(IMINIGAME_TOKEN_ID)` with the new id to satisfy the init-time `supports_interface` check in `minigame_component::initializer` / `metagame_component::initializer` for any newly-deployed game contracts that reference the upgraded token.
3. Already-deployed game/metagame contracts are unaffected — those `supports_interface` checks only fire at init time, not on subsequent calls.
4. Keep the old id `0x21c51b9820202309d87ff5d316b17b2d9280f2db9fd8fc2c6120c3a60869e49` registered too for backward compatibility — SRC5 storage is a set and both ids can coexist.

Outside this repo, the only token-aware consumers checked (`budokan`, `denshokan`, `qr-drops`) don't query `IMINIGAME_TOKEN_ID` on the token contract at all — they use the dispatcher directly — so the id change has no downstream blast radius.

## Test plan

- [ ] `scarb build` passes (verified locally)
- [ ] `snforge test token --fuzzer-runs 256` — exercise the new `mint_batch_recipients` paths and migrated tests (`test_mint_batch_recipients_empty_array_panics`, `_single`, `_multiple`, `_with_lifecycle`, `_with_counts`).
- [ ] `snforge test minigame --fuzzer-runs 256` — verify the rewritten `minigame::mint_batch` helper (now looping `dispatcher.mint()`) and the test mocks updated from `selector!("mint_batch")` to `selector!("mint")`.
- [ ] `snforge test metagame --fuzzer-runs 256` — confirm the metagame test mocks no longer declare the removed `mint_batch` stub.
- [ ] `snforge test ticket_booth --fuzzer-runs 256` — confirm the ticket booth test mock removal compiles.
- [ ] Coverage doesn't regress (project policy).

> Tests were not runnable locally — the test-artifact compile OOM-killed at ~16GB, matching the project's CI note about `ubuntu-latest-32` runners for token-heavy modules. CI is the source of truth here.

## Follow-ups (not in this PR)

- qr-drops `dungeon_denshokan.cairo:396` currently goes `minigame::mint_batch` → N×`dispatcher.mint()`. Switching it to `IMinigameTokenDispatcher::mint_batch_recipients([{receiver, count: n}], ...)` directly skips both the helper's per-token dispatcher overhead and the per-token validation prologue. Real gas win for that contract.
- `MintParams` struct is still defined and re-exported but no interface method references it anymore. Safe to delete in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Batch minting now uses a recipient-focused parameter structure (per-recipient counts) and updated batch behavior.

* **Documentation**
  * Interface docs and examples updated to show the new recipient-based batch minting API and revised token interface details.

* **Tests**
  * Test suites updated to exercise the per-recipient batching flow and new validation rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Provable-Games/game-components/pull/112)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->