### PR TITLE
feat(metagame)!: support delegated qualifier in validate_qualification

### DIFF
--- a/packages/metagame/src/entry_requirement/entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_component.cairo
@@ -235,10 +235,13 @@ pub mod EntryRequirementComponent {
         /// Validates a qualification proof against an entry requirement.
         ///
         /// `claimed_qualifier`:
-        /// - `None`: caller is the qualifier (legacy behavior).
+        /// - `None`: resolution is gate-dependent — token gates return
+        ///   `IERC721.owner_of(token_id)` (the NFT owner, *not* the caller);
+        ///   extension gates fall back to `get_caller_address()`.
         /// - `Some(addr)`: caller claims `addr` is the qualifier. For token gates, the
         ///   protocol verifies via `owner_of`; for extensions, the extension is responsible
-        ///   for verifying the claim (e.g. via signature).
+        ///   for verifying the claim (e.g. via signature recovery or merkle proof). A zero
+        ///   `addr` is rejected at the framework boundary.
         ///
         /// Returns the resolved qualifier address.
         fn validate_qualification(

--- a/packages/metagame/src/entry_requirement/entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_component.cairo
@@ -233,15 +233,23 @@ pub mod EntryRequirementComponent {
         }
 
         /// Validates a qualification proof against an entry requirement.
-        /// Returns the qualifying address (NFT owner or caller).
+        ///
+        /// `claimed_qualifier`:
+        /// - `None`: caller is the qualifier (legacy behavior).
+        /// - `Some(addr)`: caller claims `addr` is the qualifier. For token gates, the
+        ///   protocol verifies via `owner_of`; for extensions, the extension is responsible
+        ///   for verifying the claim (e.g. via signature).
+        ///
+        /// Returns the resolved qualifier address.
         fn validate_qualification(
             self: @ComponentState<TContractState>,
             context_id: u64,
             entry_requirement: EntryRequirement,
             qualifier: QualificationProof,
+            claimed_qualifier: Option<ContractAddress>,
         ) -> ContractAddress {
             EntryRequirementStoreTrait::validate_qualification(
-                self, context_id, entry_requirement, qualifier,
+                self, context_id, entry_requirement, qualifier, claimed_qualifier,
             )
         }
 

--- a/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
@@ -32,15 +32,20 @@ pub trait EntryRequirementStoreTrait<T> {
     /// Validate a qualification proof.
     ///
     /// `claimed_qualifier`:
-    /// - `None` — the caller is treated as the qualifier (legacy behavior).
-    /// - `Some(addr)` — the caller is claiming `addr` qualified. The protocol must verify
-    ///   this independently:
+    /// - `None` — behaviour is gate-dependent:
+    ///     * Token gate: returns `IERC721.owner_of(token_id)` (the resolved
+    ///       qualifier is the NFT owner, *not* the caller).
+    ///     * Extension gate: `get_caller_address()` is treated as the qualifier
+    ///       (legacy behaviour for extensions).
+    /// - `Some(addr)` — the caller is claiming `addr` qualified. The protocol must
+    ///   verify this independently:
     ///     * Token gate: asserts `IERC721.owner_of(token_id) == addr`.
     ///     * Extension: `addr` is passed to the extension as `player_address`; the
     ///       extension is responsible for verifying the delegation (e.g. signature,
-    ///       merkle proof) inside `valid_entry`. Extensions that don't verify the
-    ///       claimed qualifier MUST NOT be used in flows that pass `Some(_)` — anyone
-    ///       could otherwise mint as anyone.
+    ///       merkle proof) inside `valid_entry`. A zero `addr` is rejected at the
+    ///       framework boundary. Extensions that don't verify the claimed qualifier
+    ///       MUST NOT be used in flows that pass `Some(_)` — anyone could otherwise
+    ///       mint as anyone.
     ///
     /// Returns the resolved qualifier address.
     fn validate_qualification(
@@ -168,8 +173,18 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                 // Default: caller is qualifier (legacy). Delegated flow: caller claims
                 // `claimed_qualifier`; the extension is responsible for verifying that
                 // claim from `qualification` (e.g. signature recovery, merkle proof).
+                //
+                // A zero claimed qualifier is rejected at the framework boundary so
+                // extensions never have to defend against `player_address == 0` (some
+                // implementations would silently accept it and key state against the
+                // zero address). `get_caller_address()` is non-zero by construction.
                 let qualifier_address = match claimed_qualifier {
-                    Option::Some(addr) => addr,
+                    Option::Some(addr) => {
+                        assert!(
+                            !addr.is_zero(), "EntryRequirement: claimed qualifier cannot be zero",
+                        );
+                        addr
+                    },
                     Option::None => get_caller_address(),
                 };
                 let context_owner = get_contract_address();

--- a/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
+++ b/packages/metagame/src/entry_requirement/entry_requirement_store.cairo
@@ -29,12 +29,26 @@ pub trait EntryRequirementStoreTrait<T> {
     ) -> QualificationEntries;
     /// Set qualification entries
     fn set_qualification_entries(ref self: T, entries: @QualificationEntries);
-    /// Validate a qualification proof
+    /// Validate a qualification proof.
+    ///
+    /// `claimed_qualifier`:
+    /// - `None` — the caller is treated as the qualifier (legacy behavior).
+    /// - `Some(addr)` — the caller is claiming `addr` qualified. The protocol must verify
+    ///   this independently:
+    ///     * Token gate: asserts `IERC721.owner_of(token_id) == addr`.
+    ///     * Extension: `addr` is passed to the extension as `player_address`; the
+    ///       extension is responsible for verifying the delegation (e.g. signature,
+    ///       merkle proof) inside `valid_entry`. Extensions that don't verify the
+    ///       claimed qualifier MUST NOT be used in flows that pass `Some(_)` — anyone
+    ///       could otherwise mint as anyone.
+    ///
+    /// Returns the resolved qualifier address.
     fn validate_qualification(
         self: @T,
         context_id: u64,
         entry_requirement: EntryRequirement,
         qualifier: QualificationProof,
+        claimed_qualifier: Option<ContractAddress>,
     ) -> ContractAddress;
     /// Validate entry requirement configuration
     fn assert_valid_entry_requirement(self: @T, entry_requirement: EntryRequirement);
@@ -119,6 +133,7 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
         context_id: u64,
         entry_requirement: EntryRequirement,
         qualifier: QualificationProof,
+        claimed_qualifier: Option<ContractAddress>,
     ) -> ContractAddress {
         match entry_requirement.entry_requirement_type {
             EntryRequirementType::token(token_address) => {
@@ -129,7 +144,16 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                     ),
                 };
                 let erc721_dispatcher = IERC721Dispatcher { contract_address: token_address };
-                erc721_dispatcher.owner_of(qualification.token_id)
+                let owner = erc721_dispatcher.owner_of(qualification.token_id);
+                // If the caller claims a delegated qualifier, the on-chain owner must match.
+                // This protects against forged claims for NFT-gated requirements.
+                if let Option::Some(claimed) = claimed_qualifier {
+                    assert!(
+                        owner == claimed,
+                        "EntryRequirement: claimed qualifier does not own the gating NFT",
+                    );
+                }
+                owner
             },
             EntryRequirementType::extension(extension_config) => {
                 let qualification = match qualifier {
@@ -141,16 +165,22 @@ pub impl EntryRequirementStoreImpl<T, +Store<T>, +Drop<T>> of EntryRequirementSt
                 let extension_dispatcher = IEntryRequirementExtensionDispatcher {
                     contract_address: extension_config.address,
                 };
-                let caller_address = get_caller_address();
+                // Default: caller is qualifier (legacy). Delegated flow: caller claims
+                // `claimed_qualifier`; the extension is responsible for verifying that
+                // claim from `qualification` (e.g. signature recovery, merkle proof).
+                let qualifier_address = match claimed_qualifier {
+                    Option::Some(addr) => addr,
+                    Option::None => get_caller_address(),
+                };
                 let context_owner = get_contract_address();
                 let display_extension_address: felt252 = extension_config.address.into();
                 assert!(
                     extension_dispatcher
-                        .valid_entry(context_owner, context_id, caller_address, qualification),
+                        .valid_entry(context_owner, context_id, qualifier_address, qualification),
                     "EntryRequirement: Invalid entry according to extension {}",
                     display_extension_address,
                 );
-                caller_address
+                qualifier_address
             },
         }
     }

--- a/packages/metagame/src/entry_requirement/tests/mocks/entry_requirement_mock.cairo
+++ b/packages/metagame/src/entry_requirement/tests/mocks/entry_requirement_mock.cairo
@@ -68,8 +68,11 @@ pub mod EntryRequirementMock {
         context_id: u64,
         entry_requirement: EntryRequirement,
         qualifier: QualificationProof,
+        claimed_qualifier: Option<ContractAddress>,
     ) -> ContractAddress {
-        self.entry_req.validate_qualification(context_id, entry_requirement, qualifier)
+        self
+            .entry_req
+            .validate_qualification(context_id, entry_requirement, qualifier, claimed_qualifier)
     }
 
     #[external(v0)]

--- a/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
@@ -653,6 +653,33 @@ fn test_validate_qualification_extension_with_claimed_returns_claimed() {
 }
 
 #[test]
+fn test_validate_qualification_extension_with_none_falls_back_to_caller() {
+    // Companion to the existing `_extension_returns_caller` test, framed as a
+    // direct exercise of the `Option::None => get_caller_address()` arm of the
+    // delegation match introduced by this PR. The caller is treated as the
+    // qualifier and returned as-is.
+    let mock = deploy_entry_requirement_mock();
+    let caller = make_address(0xC0FFEE);
+    let validator_addr = deploy_entry_validator_mock(caller);
+
+    let req = EntryRequirement {
+        entry_limit: 1,
+        entry_requirement_type: EntryRequirementType::extension(
+            ExtensionConfig { address: validator_addr, config: array![].span() },
+        ),
+    };
+
+    snforge_std::cheat_caller_address(
+        mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
+    );
+    let result = mock
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![].span()), Option::None,
+        );
+    assert!(result == caller, "extension None path must resolve to caller");
+}
+
+#[test]
 #[should_panic(expected: "EntryRequirement: claimed qualifier cannot be zero")]
 fn test_validate_qualification_extension_with_zero_claimed_panics() {
     // The framework rejects a zero claimed qualifier before calling the extension

--- a/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
@@ -32,6 +32,7 @@ trait IEntryRequirementMock<TContractState> {
         context_id: u64,
         entry_requirement: EntryRequirement,
         qualifier: QualificationProof,
+        claimed_qualifier: Option<ContractAddress>,
     ) -> ContractAddress;
     fn assert_valid_entry_requirement(self: @TContractState, entry_requirement: EntryRequirement);
     fn hash_qualification_proof(self: @TContractState, proof: QualificationProof) -> felt252;
@@ -440,7 +441,9 @@ fn test_validate_qualification_token_returns_owner() {
     };
 
     let result = mock
-        .validate_qualification(1, req, QualificationProof::NFT(NFTQualification { token_id }));
+        .validate_qualification(
+            1, req, QualificationProof::NFT(NFTQualification { token_id }), Option::None,
+        );
     assert!(result == owner, "should return the NFT owner");
 }
 
@@ -455,7 +458,10 @@ fn test_validate_qualification_token_wrong_proof_type() {
     };
 
     // Pass Extension proof for a token requirement — should panic
-    mock.validate_qualification(1, req, QualificationProof::Extension(array![0x123].span()));
+    mock
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![0x123].span()), Option::None,
+        );
 }
 
 #[test]
@@ -471,7 +477,10 @@ fn test_validate_qualification_token_nonexistent_nft() {
     // Token 999 was never minted
     mock
         .validate_qualification(
-            1, req, QualificationProof::NFT(NFTQualification { token_id: 999 }),
+            1,
+            req,
+            QualificationProof::NFT(NFTQualification { token_id: 999 }),
+            Option::None,
         );
 }
 
@@ -493,7 +502,9 @@ fn test_validate_qualification_extension_returns_caller() {
         mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
     );
     let result = mock
-        .validate_qualification(1, req, QualificationProof::Extension(array![].span()));
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![].span()), Option::None,
+        );
     assert!(result == caller, "should return the caller address");
 }
 
@@ -514,7 +525,10 @@ fn test_validate_qualification_extension_rejects() {
     snforge_std::cheat_caller_address(
         mock.contract_address, caller, snforge_std::CheatSpan::TargetCalls(1),
     );
-    mock.validate_qualification(1, req, QualificationProof::Extension(array![].span()));
+    mock
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![].span()), Option::None,
+        );
 }
 
 #[test]
@@ -536,7 +550,10 @@ fn test_validate_qualification_extension_wrong_proof_type() {
     // Pass NFT proof for extension requirement — should panic
     mock
         .validate_qualification(
-            1, req, QualificationProof::NFT(NFTQualification { token_id: 0x123 }),
+            1,
+            req,
+            QualificationProof::NFT(NFTQualification { token_id: 0x123 }),
+            Option::None,
         );
 }
 

--- a/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
+++ b/packages/metagame/src/entry_requirement/tests/test_entry_requirement_component.cairo
@@ -477,10 +477,7 @@ fn test_validate_qualification_token_nonexistent_nft() {
     // Token 999 was never minted
     mock
         .validate_qualification(
-            1,
-            req,
-            QualificationProof::NFT(NFTQualification { token_id: 999 }),
-            Option::None,
+            1, req, QualificationProof::NFT(NFTQualification { token_id: 999 }), Option::None,
         );
 }
 
@@ -550,10 +547,134 @@ fn test_validate_qualification_extension_wrong_proof_type() {
     // Pass NFT proof for extension requirement — should panic
     mock
         .validate_qualification(
-            1,
-            req,
-            QualificationProof::NFT(NFTQualification { token_id: 0x123 }),
-            Option::None,
+            1, req, QualificationProof::NFT(NFTQualification { token_id: 0x123 }), Option::None,
+        );
+}
+
+// ============================================================================
+// validate_qualification with claimed_qualifier (delegated path)
+// ============================================================================
+
+#[test]
+fn test_validate_qualification_token_with_claimed_owner_succeeds() {
+    // Some(addr) where addr == owner_of(token_id) — protocol verifies via owner_of,
+    // returns the owner. Caller can be any third party.
+    let mock = deploy_entry_requirement_mock();
+    let erc721_addr = deploy_erc721_mock();
+    let token_id = 0x1234;
+    let owner = make_address(0xABCDEF);
+
+    IERC721MockSetupDispatcher { contract_address: erc721_addr }.set_owner(token_id, owner);
+
+    let req = EntryRequirement {
+        entry_limit: 1, entry_requirement_type: EntryRequirementType::token(erc721_addr),
+    };
+
+    let result = mock
+        .validate_qualification(
+            1, req, QualificationProof::NFT(NFTQualification { token_id }), Option::Some(owner),
+        );
+    assert!(result == owner, "should return the resolved owner");
+}
+
+#[test]
+#[should_panic(expected: "EntryRequirement: claimed qualifier does not own the gating NFT")]
+fn test_validate_qualification_token_with_wrong_claimed_panics() {
+    // Some(addr) where addr != owner_of(token_id) — protocol panics. Protects
+    // against forged claims for NFT-gated requirements.
+    let mock = deploy_entry_requirement_mock();
+    let erc721_addr = deploy_erc721_mock();
+    let token_id = 0x1234;
+    let owner = make_address(0xABCDEF);
+    let wrong = make_address(0xDEADBEEF);
+
+    IERC721MockSetupDispatcher { contract_address: erc721_addr }.set_owner(token_id, owner);
+
+    let req = EntryRequirement {
+        entry_limit: 1, entry_requirement_type: EntryRequirementType::token(erc721_addr),
+    };
+
+    mock
+        .validate_qualification(
+            1, req, QualificationProof::NFT(NFTQualification { token_id }), Option::Some(wrong),
+        );
+}
+
+#[test]
+#[should_panic(expected: "EntryRequirement: claimed qualifier does not own the gating NFT")]
+fn test_validate_qualification_token_with_zero_claimed_panics() {
+    // Claiming the zero address on a minted token cannot match owner_of — falls
+    // out of the same assert as the wrong-owner case. (No separate "zero" path
+    // exists for token gates: the protocol can rely on owner_of returning a real
+    // address for minted tokens.)
+    let mock = deploy_entry_requirement_mock();
+    let erc721_addr = deploy_erc721_mock();
+    let token_id = 0x1234;
+    let owner = make_address(0xABCDEF);
+    let zero: starknet::ContractAddress = 0.try_into().unwrap();
+
+    IERC721MockSetupDispatcher { contract_address: erc721_addr }.set_owner(token_id, owner);
+
+    let req = EntryRequirement {
+        entry_limit: 1, entry_requirement_type: EntryRequirementType::token(erc721_addr),
+    };
+
+    mock
+        .validate_qualification(
+            1, req, QualificationProof::NFT(NFTQualification { token_id }), Option::Some(zero),
+        );
+}
+
+#[test]
+fn test_validate_qualification_extension_with_claimed_returns_claimed() {
+    // Extension path: Some(addr) propagates `addr` to the extension as
+    // `player_address` and (on success) returns it. Caller is unrelated to addr.
+    let mock = deploy_entry_requirement_mock();
+    let mock_caller = make_address(0xCAFE);
+    let validator_addr = deploy_entry_validator_mock(mock_caller);
+    let claimed = make_address(0x1234567);
+
+    let req = EntryRequirement {
+        entry_limit: 1,
+        entry_requirement_type: EntryRequirementType::extension(
+            ExtensionConfig { address: validator_addr, config: array![].span() },
+        ),
+    };
+
+    snforge_std::cheat_caller_address(
+        mock.contract_address, mock_caller, snforge_std::CheatSpan::TargetCalls(1),
+    );
+    let result = mock
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![].span()), Option::Some(claimed),
+        );
+    assert!(result == claimed, "extension path should return the claimed qualifier");
+    assert!(result != mock_caller, "caller should not be the resolved qualifier when Some is set");
+}
+
+#[test]
+#[should_panic(expected: "EntryRequirement: claimed qualifier cannot be zero")]
+fn test_validate_qualification_extension_with_zero_claimed_panics() {
+    // The framework rejects a zero claimed qualifier before calling the extension
+    // so extensions never have to defend against `player_address == 0`.
+    let mock = deploy_entry_requirement_mock();
+    let mock_caller = make_address(0xCAFE);
+    let validator_addr = deploy_entry_validator_mock(mock_caller);
+    let zero: starknet::ContractAddress = 0.try_into().unwrap();
+
+    let req = EntryRequirement {
+        entry_limit: 1,
+        entry_requirement_type: EntryRequirementType::extension(
+            ExtensionConfig { address: validator_addr, config: array![].span() },
+        ),
+    };
+
+    snforge_std::cheat_caller_address(
+        mock.contract_address, mock_caller, snforge_std::CheatSpan::TargetCalls(1),
+    );
+    mock
+        .validate_qualification(
+            1, req, QualificationProof::Extension(array![].span()), Option::Some(zero),
         );
 }
 


### PR DESCRIPTION
## Summary
- Adds `claimed_qualifier: Option<ContractAddress>` to `EntryRequirementStoreTrait::validate_qualification` and the component wrapper. `None` preserves today's behavior; `Some(addr)` lets the caller submit a qualification on behalf of `addr`.
- **Token gate**: when `Some`, asserts `IERC721.owner_of(token_id) == addr` so the protocol verifies the claim canonically.
- **Extension gate**: when `Some`, `addr` is passed to the extension as `player_address` so the extension can verify the delegation via the qualification payload (signature, merkle proof, etc.).
- Unblocks consumer flows like "sponsor pays gas, mint routes to the NFT owner" and "qualifier gifts their entry to a third party" — for both token- and extension-gated contexts.

## Motivation
Today `validate_qualification` returns `get_caller_address()` for extensions (the caller is always treated as the qualifier) and has no recipient-redirect for token gates (the consumer has to assert ownership themselves). Consumer contracts (Budokan-style caller-vs-qualifier override, Bokendo's new batch entry path) can't route a mint to the actual qualifier when caller ≠ qualifier.

This change exposes that intent as an explicit parameter so consumers can opt in to delegated-entry flows without forking the entry-requirement plumbing.

## Security
- Token gate path is safe by construction — `owner_of` is canonical.
- Extension path moves the responsibility for verifying the claim onto extension authors. Extensions that trust `player_address` without verifying it MUST NOT be used in flows that pass `Some` — anyone could otherwise mint as anyone.
- Existing call sites pass `Option::None` and keep current behavior; the breaking signature change is the only externally visible effect for current consumers.

## Test plan
- [x] `snforge test` in `packages/metagame`: 429/429 pass (unchanged from main).
- [x] Existing validate_qualification tests updated to pass `Option::None`; semantics unchanged.
- [x] Verified end-to-end against Bokendo: new delegated-qualifier path covered by 3 bokendo tests (single-recipient redirect, wrong-claim panic, per-recipient batch).
- [ ] Add dedicated game-components tests for the `Some(_)` path before merge — wrong-owner panic + extension delegation (likely with a custom mock extension that verifies a claimed qualifier from the proof).

## Consumer migration
- Existing callers: add `, Option::None` to every `validate_qualification` invocation. No behavior change.
- Consumers that want delegation: pass `Some(claimed_qualifier)` and (if extension-gated) ensure the extension verifies the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now accepts an optional claimed qualifier so callers can assert an explicit qualifier address for entry requirements.
  * Qualification resolution still supports token-gated and extension-gated flows.

* **Tests**
  * Added tests covering claimed-qualifier success/failure paths and legacy None behavior.

* **Documentation**
  * Updated docs to describe claimed vs. legacy qualifier resolution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Provable-Games/game-components/pull/113)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->