### PR TITLE
feat(token): add refresh_metadata for state-free ERC-4906 refreshes

### DIFF
--- a/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_fuzz_mint_parameters.cairo
@@ -799,11 +799,15 @@ mod MockMinigameTokenFuzz {
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
 
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
+
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {
             self.token_player_names.write(token_id, name);
         }
 
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
 
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {
             let mut i = 0;

--- a/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_libs.cairo
@@ -1091,10 +1091,14 @@ mod MockMinigameTokenForLibs {
         }
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
+
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {
             self.token_player_names.write(token_id, name);
         }
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {}
     }
 
@@ -1914,10 +1918,14 @@ mod MockMinigameTokenWithRegistry {
         }
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
+
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {
             self.token_player_names.write(token_id, name);
         }
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {}
     }
 

--- a/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_metagame_component.cairo
@@ -924,11 +924,15 @@ mod MockMinigameToken {
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
 
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
+
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {
             self.token_player_names.write(token_id, name);
         }
 
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
 
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {
             let mut i = 0;

--- a/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
+++ b/packages/embeddable_game_standard/src/metagame/tests/test_tournament_flow.cairo
@@ -746,11 +746,15 @@ mod MockTokenContract {
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
 
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
+
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {
             self.token_player_names.write(token_id, name);
         }
 
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
 
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {
             let mut i = 0;

--- a/packages/embeddable_game_standard/src/token/interface.cairo
+++ b/packages/embeddable_game_standard/src/token/interface.cairo
@@ -68,6 +68,7 @@ pub trait IMinigameTokenMixin<TState> {
         metadata: u16,
     ) -> felt252;
     fn update_game(ref self: TState, token_id: felt252);
+    fn refresh_metadata(ref self: TState, token_id: felt252);
     fn update_player_name(ref self: TState, token_id: felt252, name: felt252);
 
     // Batch write functions
@@ -90,6 +91,7 @@ pub trait IMinigameTokenMixin<TState> {
         metadata: u16,
     ) -> Array<felt252>;
     fn update_game_batch(ref self: TState, token_ids: Span<felt252>);
+    fn refresh_metadata_batch(ref self: TState, token_ids: Span<felt252>);
     fn update_player_name_batch(ref self: TState, updates: Span<PlayerNameUpdate>);
 
     // Minter functionality

--- a/packages/embeddable_game_standard/src/token/tests/test_events.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_events.cairo
@@ -1,10 +1,14 @@
 use openzeppelin_interfaces::erc721::ERC721ABIDispatcherTrait;
-use snforge_std::{CheatSpan, EventSpyTrait, cheat_caller_address, spy_events};
-use crate::token::interface::IMinigameTokenMixinDispatcherTrait;
+use snforge_std::{
+    CheatSpan, EventSpyAssertionsTrait, EventSpyTrait, cheat_caller_address, spy_events,
+};
+use starknet::ContractAddress;
+use crate::token::interface::{IMinigameTokenMixinDispatcher, IMinigameTokenMixinDispatcherTrait};
+use crate::token::token_component::CoreTokenComponent;
 use super::mocks::minigame_mock::IMinigameMockInitDispatcherTrait;
 
 // Import IMockGameDispatcher trait
-use super::mocks::mock_game::{IMockGameDispatcherTrait};
+use super::mocks::mock_game::{IMockGameDispatcher, IMockGameDispatcherTrait};
 
 // Import test helpers from setup module
 use super::setup::{
@@ -298,4 +302,170 @@ fn test_multi_game_registry_events() {
     // Should emit TokenMinted with correct game_id
     let events = spy.get_events();
     assert!(events.events.span().len() >= 1, "Should emit TokenMinted event");
+}
+
+// ================================================================================================
+// REFRESH_METADATA TESTS
+// ================================================================================================
+
+// Mints a token against a fresh mock game and returns (token dispatcher, mock game, token id).
+fn setup_refresh_metadata() -> (
+    IMinigameTokenMixinDispatcher, IMockGameDispatcher, ContractAddress, felt252,
+) {
+    let (minigame, mock_game) = deploy_basic_mock_game();
+    let (token_dispatcher, _, _, token_address) = deploy_optimized_token_with_game(
+        minigame.contract_address,
+    );
+
+    let token_id = token_dispatcher
+        .mint(
+            minigame.contract_address,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            ALICE(),
+            false,
+            false,
+            0,
+            0,
+        );
+
+    (token_dispatcher, mock_game, token_address, token_id)
+}
+
+#[test]
+fn test_refresh_metadata_emits_metadata_update() {
+    let (token_dispatcher, _mock_game, token_address, token_id) = setup_refresh_metadata();
+
+    let mut spy = spy_events();
+    token_dispatcher.refresh_metadata(token_id);
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    token_address,
+                    CoreTokenComponent::Event::MetadataUpdate(
+                        CoreTokenComponent::MetadataUpdate { token_id: token_id.into() },
+                    ),
+                ),
+            ],
+        );
+}
+
+// The whole point of the entrypoint: it must never persist game state. A game that is over
+// on the game contract stays "not over" on the token until update_game is called, so
+// refresh_metadata can never be substituted for the game-over sync.
+#[test]
+fn test_refresh_metadata_does_not_persist_game_state() {
+    let (token_dispatcher, mock_game, _token_address, token_id) = setup_refresh_metadata();
+
+    mock_game.set_score(token_id, 100);
+    mock_game.set_game_over(token_id, true);
+
+    token_dispatcher.refresh_metadata(token_id);
+
+    let state = token_dispatcher.token_mutable_state(token_id);
+    assert!(!state.game_over, "refresh_metadata must not persist game_over");
+    assert!(!state.completed_objective, "refresh_metadata must not persist completed_objective");
+    assert!(token_dispatcher.is_playable(token_id), "token should still be playable");
+
+    // update_game is still the thing that syncs it.
+    token_dispatcher.update_game(token_id);
+    assert!(token_dispatcher.token_mutable_state(token_id).game_over, "update_game should sync");
+}
+
+#[test]
+fn test_refresh_metadata_emits_only_one_event() {
+    let (token_dispatcher, _mock_game, _token_address, token_id) = setup_refresh_metadata();
+
+    let mut spy = spy_events();
+    token_dispatcher.refresh_metadata(token_id);
+
+    let events = spy.get_events();
+    assert!(
+        events.events.span().len() == 1,
+        "refresh_metadata should emit exactly 1 event, got {}",
+        events.events.span().len(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_refresh_metadata_nonexistent_token_panics() {
+    let (token_dispatcher, _mock_game, _token_address, _token_id) = setup_refresh_metadata();
+
+    token_dispatcher.refresh_metadata(999999);
+}
+
+#[test]
+fn test_refresh_metadata_batch_emits_per_token() {
+    let (minigame, _mock_game) = deploy_basic_mock_game();
+    let (token_dispatcher, _, _, token_address) = deploy_optimized_token_with_game(
+        minigame.contract_address,
+    );
+
+    // Distinct salts, otherwise the packed token ids collide.
+    let mut token_ids: Array<felt252> = array![];
+    let mut salt: u16 = 0;
+    while salt < 3 {
+        token_ids
+            .append(
+                token_dispatcher
+                    .mint(
+                        minigame.contract_address,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        Option::None,
+                        ALICE(),
+                        false,
+                        false,
+                        salt,
+                        0,
+                    ),
+            );
+        salt += 1;
+    }
+
+    let mut spy = spy_events();
+    token_dispatcher.refresh_metadata_batch(token_ids.span());
+
+    let events = spy.get_events();
+    assert!(
+        events.events.span().len() == 3,
+        "should emit 1 event per token, got {}",
+        events.events.span().len(),
+    );
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    token_address,
+                    CoreTokenComponent::Event::MetadataUpdate(
+                        CoreTokenComponent::MetadataUpdate { token_id: (*token_ids.at(2)).into() },
+                    ),
+                ),
+            ],
+        );
+}
+
+#[test]
+#[should_panic(expected: "MinigameToken: token_ids array cannot be empty")]
+fn test_refresh_metadata_batch_empty_panics() {
+    let (token_dispatcher, _mock_game, _token_address, _token_id) = setup_refresh_metadata();
+
+    token_dispatcher.refresh_metadata_batch(array![].span());
 }

--- a/packages/embeddable_game_standard/src/token/tests/test_events.cairo
+++ b/packages/embeddable_game_standard/src/token/tests/test_events.cairo
@@ -396,12 +396,28 @@ fn test_refresh_metadata_emits_only_one_event() {
     );
 }
 
+// refresh_metadata does not check existence — see the doc comment on the entrypoint. This pins
+// that contract so a future "hardening" change has to be deliberate: consumers are responsible
+// for resolving the token id against their own record of minted tokens.
 #[test]
-#[should_panic]
-fn test_refresh_metadata_nonexistent_token_panics() {
-    let (token_dispatcher, _mock_game, _token_address, _token_id) = setup_refresh_metadata();
+fn test_refresh_metadata_unminted_token_emits_without_reverting() {
+    let (token_dispatcher, _mock_game, token_address, _token_id) = setup_refresh_metadata();
 
-    token_dispatcher.refresh_metadata(999999);
+    let unminted: felt252 = 999999;
+    let mut spy = spy_events();
+    token_dispatcher.refresh_metadata(unminted);
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    token_address,
+                    CoreTokenComponent::Event::MetadataUpdate(
+                        CoreTokenComponent::MetadataUpdate { token_id: unminted.into() },
+                    ),
+                ),
+            ],
+        );
 }
 
 #[test]

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -817,15 +817,13 @@ pub mod CoreTokenComponent {
         ///
         /// Permissionless, like `update_game`. It writes no state, so the worst case is a caller
         /// paying to trigger a re-render.
+        ///
+        /// Deliberately does not check that `token_id` exists. The event is advisory, the check
+        /// costs ~52k gas on what is meant to be the cheap path, and it would not stop spam anyway
+        /// — a caller can emit for any real token id just as easily. Consumers must resolve
+        /// `token_id` against their own record of minted tokens before acting on it; `token_uri`
+        /// reverts for a token that does not exist.
         fn refresh_metadata(ref self: ComponentState<TContractState>, token_id: felt252) {
-            let contract = self.get_contract();
-            let erc721_component = ERC721::get_component(contract);
-            assert!(
-                erc721_component.exists(token_id.into()),
-                "MinigameToken: Token {} does not exist",
-                token_id,
-            );
-
             self.emit_metadata_update(token_id.into());
         }
 

--- a/packages/embeddable_game_standard/src/token/token_component.cairo
+++ b/packages/embeddable_game_standard/src/token/token_component.cairo
@@ -807,6 +807,28 @@ pub mod CoreTokenComponent {
             }
         }
 
+        /// Emits an ERC-4906 `MetadataUpdate` for `token_id` without touching token state.
+        ///
+        /// `update_game` re-reads `game_over` and `score` from the game contract and notifies the
+        /// minter, which costs several cross-contract calls. Indexers only need the event to learn
+        /// that a token's rendered metadata is stale — `token_uri` reads score live from the game
+        /// — so games can call this after ordinary mid-game actions and reserve `update_game` for
+        /// transitions that must be persisted (game over, objective completion).
+        ///
+        /// Permissionless, like `update_game`. It writes no state, so the worst case is a caller
+        /// paying to trigger a re-render.
+        fn refresh_metadata(ref self: ComponentState<TContractState>, token_id: felt252) {
+            let contract = self.get_contract();
+            let erc721_component = ERC721::get_component(contract);
+            assert!(
+                erc721_component.exists(token_id.into()),
+                "MinigameToken: Token {} does not exist",
+                token_id,
+            );
+
+            self.emit_metadata_update(token_id.into());
+        }
+
         fn update_player_name(
             ref self: ComponentState<TContractState>, token_id: felt252, name: felt252,
         ) {
@@ -833,6 +855,21 @@ pub mod CoreTokenComponent {
                 }
                 let token_id = *token_ids.at(i);
                 self.update_game(token_id);
+                i += 1;
+            };
+        }
+
+        fn refresh_metadata_batch(
+            ref self: ComponentState<TContractState>, token_ids: Span<felt252>,
+        ) {
+            assert!(token_ids.len() > 0, "MinigameToken: token_ids array cannot be empty");
+            let mut i: u32 = 0;
+            loop {
+                if i >= token_ids.len() {
+                    break;
+                }
+                let token_id = *token_ids.at(i);
+                self.refresh_metadata(token_id);
                 i += 1;
             };
         }

--- a/packages/interfaces/src/AGENTS.md
+++ b/packages/interfaces/src/AGENTS.md
@@ -160,6 +160,23 @@ The tool outputs the extended function selectors and the final XOR'd interface I
 - For single-function interfaces, the ID equals the single extended function selector
 - Always update the EFS comment above the constant to match the tool's output
 
+### Methods excluded from `IMINIGAME_TOKEN_ID`
+
+`IMinigameToken::refresh_metadata` and `refresh_metadata_batch` are **not** part of
+the `IMINIGAME_TOKEN_ID` derivation. Omit both from the stripped input file or the
+constant will not reproduce.
+
+The ID is registered on-chain by every deployed token contract. Rederiving it to
+cover two additive, optional methods would make `supports_interface(IMINIGAME_TOKEN_ID)`
+return false on all of them and break interface discovery for every existing
+consumer — a breaking change across the ecosystem in exchange for nothing a caller
+can act on. The ID identifies the original surface, which those contracts all still
+implement in full.
+
+Apply the same reasoning to future additive methods: extend the trait, leave the ID
+alone, and note the exclusion here. Change the ID only for a genuinely breaking
+change to the existing surface.
+
 ## Dependencies
 
 None - this is a leaf package with no internal dependencies. Uses only:

--- a/packages/interfaces/src/token/core.cairo
+++ b/packages/interfaces/src/token/core.cairo
@@ -96,9 +96,11 @@ pub trait IMinigameToken<TState> {
     ) -> Array<felt252>;
 
     fn update_game(ref self: TState, token_id: felt252);
+    fn refresh_metadata(ref self: TState, token_id: felt252);
     fn update_player_name(ref self: TState, token_id: felt252, name: felt252);
 
     // Batch write functions
     fn update_game_batch(ref self: TState, token_ids: Span<felt252>);
+    fn refresh_metadata_batch(ref self: TState, token_ids: Span<felt252>);
     fn update_player_name_batch(ref self: TState, updates: Span<PlayerNameUpdate>);
 }

--- a/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
+++ b/packages/metagame/src/ticket_booth/tests/test_ticket_booth.cairo
@@ -1200,9 +1200,13 @@ mod MockMinigameTokenForTicketBooth {
 
         fn update_game(ref self: ContractState, token_id: felt252) {}
 
+        fn refresh_metadata(ref self: ContractState, token_id: felt252) {}
+
         fn update_player_name(ref self: ContractState, token_id: felt252, name: felt252) {}
 
         fn update_game_batch(ref self: ContractState, token_ids: Span<felt252>) {}
+
+        fn refresh_metadata_batch(ref self: ContractState, token_ids: Span<felt252>) {}
 
         fn update_player_name_batch(ref self: ContractState, updates: Span<PlayerNameUpdate>) {}
     }


### PR DESCRIPTION
## Summary

Adds `refresh_metadata(token_id)` and `refresh_metadata_batch(token_ids)` to `CoreTokenComponent` — an entrypoint that emits the ERC-4906 `MetadataUpdate` event and does nothing else.

`update_game` couples two separable concerns: syncing `game_over`/`completed_objective` into `token_mutable_state`, and telling indexers that a token's rendered metadata is stale. Only the first needs the cross-contract reads back into the game and the metagame callbacks. Since `token_uri` reads score live from the game contract, a bare `MetadataUpdate` is enough to keep an indexer's view fresh.

That lets a game call `refresh_metadata` after ordinary mid-game actions and reserve `update_game` for transitions that must be persisted (game over, objective completion), instead of choosing between paying for the full callback on every action or dropping the event entirely and letting indexed state go stale.

```cairo
fn refresh_metadata(ref self: ComponentState<TContractState>, token_id: felt252) {
    self.emit_metadata_update(token_id.into());
}
```

## Changes

- `CoreTokenComponent`: `refresh_metadata` and `refresh_metadata_batch`. The batch form mirrors `update_game_batch` — same empty-array assert, same loop.
- `IMinigameToken` (`packages/interfaces/src/token/core.cairo`) and the `IMinigameTokenMixin` dispatcher interface gain both methods.
- Six mock `IMinigameToken` implementations across the metagame and ticket-booth tests get no-op stubs, since adding trait methods breaks implementors.

No storage layout, event, or existing-entrypoint changes. Downstream token contracts that embed `CoreTokenImpl` pick the entrypoints up with no code change.

## Permissionless, and no existence check

`refresh_metadata` is callable by anyone and deliberately does **not** verify that `token_id` exists.

An existence check measured ~52k l2 gas on what is meant to be the cheap path, and it bought nothing defensively: a caller who wants to spam `MetadataUpdate` can do it with any real token id, so the check only blocked the harmless variant. The event is advisory.

The contract for consumers: resolve `token_id` against your own record of minted tokens before acting on it. `token_uri` reverts for a token that does not exist, so an indexer that blindly fetches on every event will burn RPC calls on ids that were never minted (or have since been burned). `test_refresh_metadata_unminted_token_emits_without_reverting` pins this so a future "hardening" change has to be deliberate.

## What it deliberately does not do

`refresh_metadata` never writes `token_mutable_state`. A game that is over on the game contract stays "not over" on the token until `update_game` runs, so this cannot be substituted for the game-over sync — `is_playable`, `assert_playable`, and the `on_game_over` callback keep working exactly as before. `test_refresh_metadata_does_not_persist_game_state` pins that: it sets the mock game to `game_over = true`, calls `refresh_metadata`, asserts the token is still playable, then calls `update_game` and asserts it syncs.

## Gas

Like-for-like against `update_game` — identical deploys, mint, and `set_score`, differing only in the final call:

| call | l2 gas |
|---|---:|
| `update_game` | 8,278,460 |
| `refresh_metadata` | 7,567,904 |
| **saved** | **710,556** |

Dropping the existence check saves a further ~52,530. Treat the total as a floor rather than the expected saving: the mock game's `game_over()` and `score()` are trivial storage reads, whereas in a real game they re-run the game's own state loading, which is where the cost actually lives.

## Test plan

- [x] `scarb build` clean
- [x] `snforge test -p game_components_embeddable_game_standard` — 1133/1133 pass
- [x] `snforge test -p game_components_metagame` — 437/437 pass
- [x] `scarb fmt --check --workspace` clean
- [x] `git diff --check` clean

Six new tests in `token/tests/test_events.cairo`: exact-event assertion, no-state-persistence, single-event emission, unminted-token emits without reverting, per-token batch emission, empty-batch panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token metadata refresh entrypoints for a single token and for a batch.
  * Refresh operations emit ERC-4906 `MetadataUpdate` events and do not modify gameplay-related token state.
  * Refreshing an unrecognized token ID still emits the expected event; empty batch inputs are rejected.
* **Tests**
  * Added event-focused test coverage for both refresh modes, including batch length edge cases and checks that token mutable state is not persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->